### PR TITLE
feat：Agent HITL 审批与 checkpoint 持久化

### DIFF
--- a/backend/app/agent/agent.py
+++ b/backend/app/agent/agent.py
@@ -1,11 +1,13 @@
 import asyncio
 import inspect
 import json
+import uuid
 from collections.abc import AsyncGenerator
 
 from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.tools import BaseTool
+from langgraph.types import Command
 
 from app.core.settings import settings
 
@@ -22,7 +24,9 @@ from app.agent.agent_tools import (
     set_thinking_callback,
     what_time_is_now,
 )
+from app.agent.agent_middleware import DEFAULT_APPROVAL_TOOLS, get_middleware
 from app.agent.agent_rag_tool import init_rag_guard, search_rag
+from app.agent.checkpoint.mysql_saver import MySQLCheckpointSaver
 from app.core.logger_handler import logger
 from app.services import session_manager as sm
 from app.utils.prompt_loader import load_prompt
@@ -44,6 +48,7 @@ class AgentFactory:
             default_tools: list[BaseTool] | None = None,
             default_middleware: list | None = None,
             default_system_prompt: str | None = None,
+            approval_tools: dict | None = None,
     ):
         """
         初始化工厂配置（仅配置，不创建实例）
@@ -51,10 +56,12 @@ class AgentFactory:
         :param api_key: 默认 API Key（不传则从env读取）
         :param default_tools: 默认工具列表
         :param default_system_prompt: 默认系统提示词
+        :param approval_tools: HITL 审批白名单（{工具名: {"allowed_decisions": [...]}}）
         """
         self.model = model
         self.api_key = api_key or settings.CHAT_API_KEY or None
         self.default_tools = default_tools or self._get_default_tools()
+        self.approval_tools = approval_tools or DEFAULT_APPROVAL_TOOLS
         self.default_middleware = default_middleware or self._get_default_middleware()
         self.default_system_prompt = default_system_prompt or self._get_default_system_prompt()
 
@@ -74,11 +81,11 @@ class AgentFactory:
         ]
 
     def _get_default_middleware(self) -> list:
-        """获取默认中间件列表"""
+        """获取默认中间件列表（含 HITL 审批中间件，白名单可配置）"""
         try:
             from app.agent.agent_middleware import get_middleware
 
-            return get_middleware()
+            return get_middleware(self.approval_tools)
         except ImportError:
             logger.warning("Agent middleware unavailable; continuing without middleware.", exc_info=True)
             return []
@@ -132,8 +139,44 @@ class AgentFactory:
             tools,
             system_prompt=system_prompt,
             middleware=self.default_middleware,
+            checkpointer=get_checkpointer(),
             **kwargs
         )
+
+
+# 全局共享的 checkpointer：懒加载，测试可 monkeypatch get_checkpointer
+_checkpointer = None
+_checkpointer_factory = None
+
+
+def get_checkpointer():
+    """返回全局 MySQL checkpointer（懒创建，捕获调用时的 AsyncSessionLocal）。"""
+    global _checkpointer
+    if _checkpointer is None:
+        from app.db.db_config import AsyncSessionLocal
+
+        _checkpointer = MySQLCheckpointSaver(session_factory=AsyncSessionLocal)
+    return _checkpointer
+
+
+def reset_checkpointer():
+    """测试用：清空全局 checkpointer 单例。"""
+    global _checkpointer
+    _checkpointer = None
+
+
+# 同一会话 run/resume 互斥锁（进程内；键为 user_id:session_id）。
+_session_locks: dict[str, asyncio.Lock] = {}
+
+
+def _get_session_lock(user_id: str, session_id: str) -> asyncio.Lock:
+    """同一会话的 run/resume 互斥锁（进程内；键为 user_id:session_id）。"""
+    key = f"{user_id}:{session_id}"
+    lock = _session_locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _session_locks[key] = lock
+    return lock
 
 
 # 初始化全局工厂配置
@@ -194,23 +237,52 @@ async def get_agent_response(
     :param custom_tools: 自定义工具（可选，用于动态切换工具）
     :param kwargs: 其他工厂参数
     :return: 响应结果
+
+    注意：非流式调用者（如 evals）应使用只读工具；命中审批白名单工具时
+    本函数不走审批流程，而是返回 {"interrupted": True, "run_id": ...} 结构化信号，
+    调用方须经流式 resume 路径（get_agent_resume_stream_response）携带 run_id 继续。
     """
     if user_id:
         set_current_user_id(user_id)
 
+    # 非流式路径使用一次性 thread：checkpointer 要求 configurable 含 thread_id，
+    # run 结束后删除该 thread，保持“无状态一次性调用”语义（流式持久化是 Task 5 的事）。
+    thread_id = str(uuid.uuid4())
+    saver = None
+    saw_interrupt = False
+
     try:
+        saver = get_checkpointer()
         # 1. 从工厂获取全新的 Agent 编译图实例
         agent = agent_factory.create_agent(custom_tools=custom_tools, **kwargs)
 
         # 2. 构建消息状态（历史 + 当前问题）
         chat_history = _build_chat_history(history)
-        state = await agent.ainvoke({"messages": [*chat_history, HumanMessage(content=query)]})
+        config = {"configurable": {"thread_id": thread_id}}
+        state = await agent.ainvoke(
+            {"messages": [*chat_history, HumanMessage(content=query)]},
+            config,
+        )
 
         # 3. 最终回答 = 消息状态中最后一条 AIMessage
         messages = state.get("messages", [])
         final = next((m for m in reversed(messages) if isinstance(m, AIMessage)), None)
         response = (final.content or "") if final is not None else ""
         steps = _collect_steps(messages)
+
+        # 4. HITL 中断检测：白名单工具请求会停在 __interrupt__，此时不得删除
+        # thread（保持可恢复/可检查），返回结构化信号而非误导性文本答复。
+        snapshot = await agent.aget_state(config)
+        if _interrupt_payload(snapshot) is not None:
+            saw_interrupt = True
+            return {
+                "response": "该操作需要人工审批（命中审批白名单工具），非流式调用无法完成审批；"
+                            "已保留执行现场，请使用流式 resume 接口（get_agent_resume_stream_response）"
+                            "携带 run_id 继续。",
+                "steps": steps,
+                "interrupted": True,
+                "run_id": thread_id,
+            }
 
         return {
             "response": response if response else "抱歉，我无法理解您的请求。",
@@ -223,6 +295,245 @@ async def get_agent_response(
             "response": f"抱歉，处理您的请求时出现了错误: {str(e)}",
             "steps": []
         }
+    finally:
+        # 仅无中断时清理一次性 thread；中断时保留现场供 resume/检查。
+        if saver is not None and not saw_interrupt:
+            try:
+                await saver.adelete_thread(thread_id)
+            except Exception as cleanup_error:
+                logger.warning(f"清理非流式 run thread 失败（可忽略）: {cleanup_error}")
+
+def _thread_config(run_id: str) -> dict:
+    """单次 run 的 thread config。"""
+    return {"configurable": {"thread_id": run_id}}
+
+
+async def _last_human_query(messages: list[BaseMessage]) -> str:
+    """取 state 中最后一个 HumanMessage 作为原始 query。"""
+    for msg in reversed(messages):
+        if isinstance(msg, HumanMessage):
+            return str(msg.content)
+    return ""
+
+
+def _interrupt_payload(snapshot) -> dict | None:
+    """从 aget_state 快照提取 HITL 中断负载。"""
+    for interrupt in getattr(snapshot, "interrupts", ()) or ():
+        value = getattr(interrupt, "value", None)
+        if isinstance(value, dict) and "action_requests" in value:
+            return value
+    return None
+
+
+def _extract_interrupt_payload(value) -> dict | None:
+    """从 pending_write 值中提取 HITL 负载（兼容裸 Interrupt/(id, Interrupt)/list 形态）。"""
+    candidates = list(value) if isinstance(value, list) else [value]
+    for candidate in candidates:
+        if isinstance(candidate, tuple) and len(candidate) == 2:
+            candidate = candidate[1]
+        inner = getattr(candidate, "value", candidate)
+        if isinstance(inner, dict) and "action_requests" in inner:
+            return inner
+    return None
+
+
+async def read_pending_interrupt(run_id: str) -> dict | None:
+    """只读恢复：从 checkpoint 读待审批中断负载与原始 query（不编译图）。
+
+    返回 {"run_id", "payload", "query"}；无 checkpoint/无中断返回 None。
+    """
+    saver = get_checkpointer()
+    try:
+        tup = await saver.aget_tuple(_thread_config(run_id))
+    except Exception as e:
+        logger.error(f"读取 pending interrupt 失败: {e}", exc_info=True)
+        return None
+    if tup is None:
+        return None
+    payload = None
+    for entry in (tup.pending_writes or []):
+        # pending_writes 形态随版本而异：3 元组 (task_id, channel, value)
+        # 或 4 元组 (task_id, channel, type, value)；value 取最后一项。
+        if len(entry) < 3:
+            continue
+        channel, value = entry[1], entry[-1]
+        if channel != "__interrupt__":
+            continue
+        payload = _extract_interrupt_payload(value)
+        if payload is not None:
+            break
+    if payload is None:
+        return None
+    messages = (tup.checkpoint.get("channel_values") or {}).get("messages", []) or []
+    return {
+        "run_id": run_id,
+        "payload": payload,
+        "query": await _last_human_query(messages),
+    }
+
+
+def _writes_have_interrupt(pending_writes) -> bool:
+    """pending_writes 里是否含 __interrupt__ 通道（3/4 元组形态兼容）。"""
+    for entry in (pending_writes or []):
+        if len(entry) < 3:
+            continue
+        if entry[1] == "__interrupt__":
+            return True
+    return False
+
+
+async def _pending_is_active(pending_run_id: str) -> bool:
+    """pending 指向的 run 是否仍在等审批。
+
+    审批完成后 thread 会被保留（供查看审批前快照），此时最新 checkpoint
+    已无中断。读不到/异常一律按 active 处理：宁可挡住新问题，也不丢审批现场。
+    saver 无 aget_tuple 方法时（如单测替身）同样按 active 处理，保持旧行为。
+    """
+    saver = get_checkpointer()
+    if getattr(saver, "aget_tuple", None) is None:
+        return True
+    try:
+        tup = await saver.aget_tuple(_thread_config(pending_run_id))
+    except Exception:
+        return True
+    if tup is None:
+        return True
+    return _writes_have_interrupt(tup.pending_writes)
+
+
+async def read_approval_snapshot(run_id: str) -> dict | None:
+    """读取该 run 的审批前快照（含已审批完成）：扫描 thread 历史找最新 __interrupt__。
+
+    返回 {"run_id", "payload", "query", "checkpoint_id", "active"}；
+    active=True 表示仍在等审批，False 表示已审批完成（thread 被保留）；
+    该 run 从无审批返回 None。不编译图，saver 无历史方法时返回 None。
+    """
+    saver = get_checkpointer()
+    if getattr(saver, "aget_tuple", None) is None or getattr(saver, "alist", None) is None:
+        return None
+    try:
+        latest = await saver.aget_tuple(_thread_config(run_id))
+    except Exception as e:
+        logger.error(f"读取审批快照失败: {e}", exc_info=True)
+        return None
+    if latest is None:
+        return None
+    if _writes_have_interrupt(latest.pending_writes):
+        messages = (latest.checkpoint.get("channel_values") or {}).get("messages", []) or []
+        for entry in latest.pending_writes:
+            if len(entry) < 3 or entry[1] != "__interrupt__":
+                continue
+            payload = _extract_interrupt_payload(entry[-1])
+            if payload is not None:
+                return {
+                    "run_id": run_id,
+                    "payload": payload,
+                    "query": await _last_human_query(messages),
+                    "checkpoint_id": latest.config["configurable"].get("checkpoint_id"),
+                    "active": True,
+                }
+        return None
+    try:
+        async for hist in saver.alist(_thread_config(run_id)):
+            cid = (hist.config.get("configurable") or {}).get("checkpoint_id")
+            if not cid:
+                continue
+            tup = await saver.aget_tuple(
+                {"configurable": {"thread_id": run_id, "checkpoint_id": cid}})
+            if tup is None or not _writes_have_interrupt(tup.pending_writes):
+                continue
+            messages = (tup.checkpoint.get("channel_values") or {}).get("messages", []) or []
+            for entry in tup.pending_writes:
+                if len(entry) < 3 or entry[1] != "__interrupt__":
+                    continue
+                payload = _extract_interrupt_payload(entry[-1])
+                if payload is not None:
+                    return {
+                        "run_id": run_id,
+                        "payload": payload,
+                        "query": await _last_human_query(messages),
+                        "checkpoint_id": cid,
+                        "active": False,
+                    }
+    except Exception as e:
+        logger.error(f"扫描审批历史失败: {e}", exc_info=True)
+        return None
+    return None
+
+
+def _message_text(output) -> str:
+    """从模型消息/终态输出提取文本（str/list content 形态）。"""
+    content = getattr(output, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(item.get("text", "") for item in content if isinstance(item, dict))
+    return ""
+
+
+async def _emit_agent_events(agent, inputs, config, thinking_queue, full_response):
+    """执行 astream_events 并转发 thinking/response 事件。
+
+    返回 (interrupted_payload_or_None, error_str_or_None)。
+    - 正常结束：检测 aget_state 的 interrupts 负载，返回负载或 None。
+    - 异常：返回 (None, 错误文本)。
+    """
+    async def emit_thinking(stage, content, details):
+        callback = get_thinking_callback_from_context()
+        if callback is None:
+            return
+        result = callback({"type": "thinking", "stage": stage,
+                           "content": content, "details": details})
+        if inspect.isawaitable(result):
+            await result
+
+    async def emit_response(content: str):
+        if not content:
+            return
+        full_response.append(content)
+        await thinking_queue.put({"type": "response", "content": content})
+
+    try:
+        async for event in agent.astream_events(inputs, config=config, version="v2"):
+            event_type = event.get("event")
+            event_data = event.get("data") or {}
+            if event_type == "on_chat_model_stream":
+                chunk = event_data.get("chunk")
+                if getattr(chunk, "tool_call_chunks", None):
+                    continue
+                content = getattr(chunk, "content", None)
+                if content is None and isinstance(chunk, dict):
+                    content = chunk.get("content")
+                if isinstance(content, str):
+                    await emit_response(content)
+                elif isinstance(content, list):
+                    text = "".join(item.get("text", "")
+                                   for item in content if isinstance(item, dict))
+                    await emit_response(text)
+            elif event_type == "on_tool_start":
+                tool = event.get("name", "unknown_tool")
+                await emit_thinking("tool_start", f"正在调用 {tool}",
+                                    {"tool": tool, "tool_input": event_data.get("input")})
+            elif event_type == "on_tool_end":
+                tool = event.get("name", "unknown_tool")
+                tool_output = event_data.get("output")
+                if isinstance(tool_output, BaseMessage):
+                    tool_output = tool_output.content
+                await emit_thinking("tool_end", f"{tool} 执行完成",
+                                    {"tool": tool, "tool_output": tool_output})
+            elif event_type == "on_chat_model_end":
+                # 非流式/假模型不产生 on_chat_model_stream，这里兜底收割最终文本；
+                # 真实流式模型已逐块累积（full_response 非空）则跳过，避免重复。
+                if not full_response:
+                    await emit_response(_message_text(event_data.get("output")))
+        # 结束后检测中断点：以 interrupts 负载为准（挂起节点名随版本而异，
+        # 如 HumanInTheLoopMiddleware.after_model，不可硬编码 '__interrupt__'）。
+        snapshot = await agent.aget_state(config)
+        return _interrupt_payload(snapshot), None
+    except Exception as e:
+        logger.error(f"Agent 执行错误: {e}", exc_info=True)
+        return None, str(e)
+
 
 async def get_agent_stream_response(
         query: str,
@@ -233,188 +544,255 @@ async def get_agent_stream_response(
         rag_searched_queries: list[str] | None = None,
         **kwargs
 ) -> AsyncGenerator[str, None]:
+    """获取 Agent 流式响应（含 HITL 中断）。
+
+    - 若会话存在 pending_run_id：发 PENDING_EXISTS error 帧结束。
+    - 正常完成：写 ChatMessage 并删除 thread。
+    - 遇 __interrupt__：写 pending_run_id，发 interrupt 帧结束（不落镜像）。
+    - 同一会话的 run/resume 由进程内锁串行化（见 _get_session_lock）。
     """
-    获取 Agent 流式响应（包含思考过程，实时推送）
-    :param query: 用户查询
-    :param session_id: 会话 ID
-    :param user_id: 用户 ID
-    :param custom_tools: 自定义工具（可选）
-    :param rag_context: 预检索的 RAG 上下文（由路由层注入，为空则跳过）
-    :param rag_searched_queries: 前置 RAG 管线本轮已检索的 query 集合（预置护栏去重）
-    :param kwargs: 其他参数
-    :return: 流式响应生成器
-    """
+    async with _get_session_lock(user_id, session_id):
+        thinking_queue = asyncio.Queue()
+        agent_result_holder = {"interrupt": None, "error": None}
+        agent_done = asyncio.Event()
+        run_id = str(uuid.uuid4())
 
-    thinking_queue = asyncio.Queue()
-    agent_result_holder = {"response": None, "error": None}
-    agent_done = asyncio.Event()
+        async def thinking_callback(data: dict):
+            logger.info(f"【思考过程】{data.get('stage', 'unknown')}: {data.get('content', '')}")
+            await thinking_queue.put(data)
 
-    async def thinking_callback(data: dict):
-        """思考过程回调函数，将事件放入队列"""
-        logger.info(f"【思考过程】{data.get('stage', 'unknown')}: {data.get('content', '')}")
-        await thinking_queue.put(data)
+        async def run_agent():
+            try:
+                set_current_user_id(user_id)
+                set_thinking_callback(thinking_callback)
+                init_rag_guard(rag_searched_queries)
 
-    async def run_agent():
-        """在独立任务中执行 Agent"""
-        try:
-            set_current_user_id(user_id)
-            set_thinking_callback(thinking_callback)
-            init_rag_guard(rag_searched_queries)
+                # 顶层守卫：仍在等审批时拒绝新问题；已审批完成的历史 pending
+                # （thread 被保留供查看）放行，其 pending 会在下次中断时被覆盖。
+                pending = await sm.session_manager.get_pending_run_id(session_id, user_id)
+                if pending and await _pending_is_active(pending):
+                    agent_result_holder["error"] = "PENDING_EXISTS"
+                    return
 
-            history = await sm.session_manager.get_history(session_id, user_id)
-            logger.info(f"【Agent流式响应】获取会话历史成功，历史记录数: {len(history)}")
-
-            chat_history = _build_chat_history(history)
-
-            # 根据是否有 RAG 上下文决定 system prompt 内容
-            if rag_context:
+                history = await sm.session_manager.get_history(session_id, user_id)
+                chat_history = _build_chat_history(history)
                 system_prompt = (
                     load_prompt("rag_context_prompt").replace("{context}", rag_context)
+                    if rag_context else agent_factory.default_system_prompt
                 )
-            else:
-                system_prompt = agent_factory.default_system_prompt
+                agent = agent_factory.create_agent(
+                    custom_tools=custom_tools, custom_system_prompt=system_prompt, **kwargs
+                )
+                full_response = []
+                inputs = {"messages": [*chat_history, HumanMessage(content=query)]}
+                config = _thread_config(run_id)
+                interrupted, error = await _emit_agent_events(
+                    agent, inputs, config, thinking_queue, full_response)
 
-            agent = agent_factory.create_agent(
-                custom_tools=custom_tools, custom_system_prompt=system_prompt, **kwargs
-            )
-
-            full_response = []
-
-            async def emit_thinking(stage: str, content: str, details: dict):
-                callback = get_thinking_callback_from_context()
-                if callback is None:
+                if error:
+                    agent_result_holder["error"] = error
                     return
-                result = callback({
-                    "type": "thinking",
-                    "stage": stage,
-                    "content": content,
-                    "details": details,
-                })
-                if inspect.isawaitable(result):
-                    await result
 
-            async def emit_response(content: str):
-                if not content:
+                if interrupted is not None:
+                    # 等待用户审批：记录 run_id，不写镜像，保留 checkpoint。
+                    # 先记 holder 再写 pending，保证 set_pending 失败时 finally
+                    # 仍能看到中断而不误删已停靠的 thread。
+                    agent_result_holder["interrupt"] = {
+                        "run_id": run_id, "payload": interrupted}
+                    if pending and pending != run_id:
+                        # 覆盖上次已审批完成的历史 thread，避免无索引孤儿越积越多。
+                        try:
+                            await get_checkpointer().adelete_thread(pending)
+                        except Exception as cleanup_error:
+                            logger.warning(f"清理历史审批 thread 失败（可忽略）: {cleanup_error}")
+                    await sm.session_manager.set_pending_run_id(session_id, user_id, run_id)
                     return
-                full_response.append(content)
-                await thinking_queue.put({
-                    "type": "response",
-                    "content": content,
-                })
 
-            inputs = {
-                "messages": [*chat_history, HumanMessage(content=query)],
-            }
+                response = "".join(full_response) if full_response else "抱歉，我无法理解您的请求。"
+                agent_result_holder["response"] = response
+                # 正常完成：落镜像（thread 清理统一由 finally 的守卫删除负责）
+                await sm.session_manager.add_message(session_id, user_id, query, response)
+            except Exception as e:
+                logger.error(f"【Agent流式响应】Agent执行失败: {e}", exc_info=True)
+                # 已记录中断时保留中断信号，不被错误覆盖（thread 必须保留）。
+                if agent_result_holder.get("interrupt") is None:
+                    agent_result_holder["error"] = str(e)
+            finally:
+                # 孤儿清理：仅无中断且非 PENDING_EXISTS 守卫时删除本 run 的 thread。
+                # 中断已记录 → 永不删除（pending 指向它）；守卫路径未产生 thread 内容 → 跳过。
+                if (agent_result_holder.get("interrupt") is None
+                        and agent_result_holder.get("error") != "PENDING_EXISTS"):
+                    try:
+                        await get_checkpointer().adelete_thread(run_id)
+                    except Exception as cleanup_error:
+                        logger.warning(f"清理 thread 失败（可忽略）: {cleanup_error}")
+                agent_done.set()
 
-            # 规划轮（工具调用前的模型轮）chunk 携带 tool_call_chunks 增量，直接丢弃；
-            # 纯文本 chunk 实时转发——最终回答的 token 边生成边推，恢复打字机效果。
-            async for event in agent.astream_events(inputs, version="v2"):
-                event_type = event.get("event")
-                event_data = event.get("data") or {}
+        agent_task = asyncio.create_task(run_agent())
+        try:
+            yield f"data: {json.dumps({'type': 'response', 'content': '', 'session_id': session_id}, ensure_ascii=False)}\n\n"
+            while not agent_done.is_set():
+                try:
+                    event = await asyncio.wait_for(thinking_queue.get(), timeout=0.1)
+                    yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+                    thinking_queue.task_done()
+                except TimeoutError:
+                    continue
+            while not thinking_queue.empty():
+                try:
+                    event = thinking_queue.get_nowait()
+                    yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+                    thinking_queue.task_done()
+                except asyncio.QueueEmpty:
+                    break
+            await agent_task
 
-                if event_type == "on_chat_model_stream":
-                    chunk = event_data.get("chunk")
-                    # 规划轮 chunk 带 tool_call_chunks（工具参数增量），不流入 response
-                    if getattr(chunk, "tool_call_chunks", None):
-                        continue
-                    content = getattr(chunk, "content", None)
-                    if content is None and isinstance(chunk, dict):
-                        content = chunk.get("content")
-                    if isinstance(content, str):
-                        await emit_response(content)
-                    elif isinstance(content, list):
-                        text = "".join(
-                            item.get("text", "")
-                            for item in content
-                            if isinstance(item, dict)
-                        )
-                        await emit_response(text)
-                elif event_type == "on_tool_start":
-                    tool = event.get("name", "unknown_tool")
-                    tool_input = event_data.get("input")
-                    await emit_thinking(
-                        "tool_start",
-                        f"正在调用 {tool}",
-                        {"tool": tool, "tool_input": tool_input},
-                    )
-                elif event_type == "on_tool_end":
-                    tool = event.get("name", "unknown_tool")
-                    tool_output = event_data.get("output")
-                    # LangGraph 的 on_tool_end output 是 ToolMessage 对象，
-                    # 需提取 content 才能 JSON 序列化进 thinking 事件
-                    if isinstance(tool_output, BaseMessage):
-                        tool_output = tool_output.content
-                    await emit_thinking(
-                        "tool_end",
-                        f"{tool} 执行完成",
-                        {"tool": tool, "tool_output": tool_output},
-                    )
+            if agent_result_holder.get("interrupt"):
+                payload = agent_result_holder["interrupt"]
+                yield f"data: {json.dumps({'type': 'interrupt', **payload, 'session_id': session_id}, ensure_ascii=False)}\n\n"
+                return
+            if agent_result_holder.get("error"):
+                content = agent_result_holder["error"]
+                yield f"data: {json.dumps({'type': 'error', 'content': content, 'session_id': session_id}, ensure_ascii=False)}\n\n"
+                yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"
+                return
 
-            agent_result_holder["response"] = "".join(full_response) if full_response else "抱歉，我无法理解您的请求。"
+            response = agent_result_holder.get("response") or "抱歉，我无法理解您的请求。"
+            yield f"data: {json.dumps({'type': 'done', 'session_id': session_id}, ensure_ascii=False)}\n\n"
         except Exception as e:
-            logger.error(f"【Agent流式响应】Agent执行失败: {e}", exc_info=True)
-            agent_result_holder["error"] = str(e)
-        finally:
-            agent_done.set()
-
-    # 启动 Agent 执行任务
-    agent_task = asyncio.create_task(run_agent())
-
-    try:
-        logger.info(f"【Agent流式响应】开始处理请求，用户ID: {user_id}, 会话ID: {session_id}, 查询: {query}")
-
-        # 先发送初始响应
-        yield f"data: {json.dumps({'type': 'response', 'content': '', 'session_id': session_id}, ensure_ascii=False)}\n\n"
-
-        # 持续监听队列并实时推送思考事件，同时等待 Agent 完成
-        while not agent_done.is_set():
+            logger.error(f"【Agent流式响应】处理请求失败: {e}", exc_info=True)
+            agent_task.cancel()
             try:
-                # 使用短超时轮询队列，实现实时推送
-                event = await asyncio.wait_for(thinking_queue.get(), timeout=0.1)
-                yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
-                thinking_queue.task_done()
-            except TimeoutError:
-                # 超时是正常的，继续等待
-                continue
-
-        # Agent 已完成，推送队列中剩余的所有思考事件
-        while not thinking_queue.empty():
-            try:
-                event = thinking_queue.get_nowait()
-                yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
-                thinking_queue.task_done()
-            except asyncio.QueueEmpty:
-                break
-
-        # 等待 agent_task 完全结束
-        await agent_task
-
-        if agent_result_holder["error"]:
-            error_message = f"错误: {agent_result_holder['error']}"
+                await agent_task
+            except asyncio.CancelledError:
+                pass
+            # 外部取消/断开兜底：无中断且非守卫路径才删（run_agent 的 finally
+            # 通常已删，此处为幂等兜底，守卫删除永不抛错）。
+            if (agent_result_holder.get("interrupt") is None
+                    and agent_result_holder.get("error") != "PENDING_EXISTS"):
+                try:
+                    await get_checkpointer().adelete_thread(run_id)
+                except Exception as cleanup_error:
+                    logger.warning(f"清理 thread 失败（可忽略）: {cleanup_error}")
+            error_message = f"错误: {str(e)}"
             yield f"data: {json.dumps({'type': 'error', 'content': error_message, 'session_id': session_id}, ensure_ascii=False)}\n\n"
             yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"
-            return
 
-        response = agent_result_holder["response"]
 
-        # 添加到会话历史
-        await sm.session_manager.add_message(session_id, user_id, query, response)
-        logger.info("【Agent流式响应】添加到会话历史成功")
+async def get_agent_resume_stream_response(
+        session_id: str,
+        user_id: str,
+        run_id: str,
+        decisions: list[dict],
+        custom_tools: list[BaseTool] | None = None,
+        **kwargs
+) -> AsyncGenerator[str, None]:
+    """以相同 thread 恢复被中断的 run（Command(resume=...)）。
 
-        # 发送结束标记
-        yield f"data: {json.dumps({'type': 'done', 'session_id': session_id}, ensure_ascii=False)}\n\n"
-        logger.info(f"【Agent流式响应】处理完成，会话ID: {session_id}")
+    - 校验该会话确有 pending_run_id==run_id，否则 error 帧。
+    - 完成：镜像落库；thread 与 pending 保留（供查看审批前快照，下次中断覆盖）。
+    - 再次 resume 同一已完成 run：ALREADY_COMPLETED error 帧（不重复执行）。
+    - 再次中断：更新 payload 再发 interrupt 帧。
+    - 出错：不删 thread、不清 pending（预留 pending 供重试）。
+    - 同一会话的 run/resume 由进程内锁串行化（见 _get_session_lock）。
+    """
+    async with _get_session_lock(user_id, session_id):
+        thinking_queue = asyncio.Queue()
+        agent_result_holder = {"interrupt": None, "error": None}
+        agent_done = asyncio.Event()
 
-    except Exception as e:
-        logger.error(f"【Agent流式响应】处理请求失败: {e}", exc_info=True)
+        async def thinking_callback(data: dict):
+            logger.info(f"【思考过程-恢复】{data.get('stage', 'unknown')}: {data.get('content', '')}")
+            await thinking_queue.put(data)
 
-        # 取消 agent 任务
-        agent_task.cancel()
+        async def run_agent():
+            try:
+                set_current_user_id(user_id)
+                set_thinking_callback(thinking_callback)
+                pending = await sm.session_manager.get_pending_run_id(session_id, user_id)
+                if pending != run_id:
+                    agent_result_holder["error"] = "RESUME_MISMATCH"
+                    return
+                # 已完成重放保护：审批完成后 thread 被保留供查看，同一 run 再次
+                # resume 不得重复执行工具/落镜像。saver 不可读时（如单测替身）放行。
+                saver = get_checkpointer()
+                if getattr(saver, "aget_tuple", None) is not None:
+                    try:
+                        cur = await saver.aget_tuple(_thread_config(run_id))
+                    except Exception as e:
+                        logger.error(f"恢复前检查 thread 失败: {e}", exc_info=True)
+                        agent_result_holder["error"] = "RESUME_CHECK_FAILED"
+                        return
+                    if cur is None:
+                        agent_result_holder["error"] = "RESUME_MISMATCH"
+                        return
+                    if not _writes_have_interrupt(cur.pending_writes):
+                        agent_result_holder["error"] = "ALREADY_COMPLETED"
+                        return
+
+                agent = agent_factory.create_agent(
+                    custom_tools=custom_tools, **kwargs)
+                config = _thread_config(run_id)
+                command = Command(resume={"decisions": decisions})
+                full_response = []
+                interrupted, error = await _emit_agent_events(
+                    agent, command, config, thinking_queue, full_response)
+                if error:
+                    # 出错保留 thread 与 pending，供重试（不删不清除）。
+                    agent_result_holder["error"] = error
+                    return
+                if interrupted is not None:
+                    agent_result_holder["interrupt"] = {"run_id": run_id, "payload": interrupted}
+                    return
+
+                # 完成：原始 query 从 checkpoint 读取（不依赖首跑请求参数）。
+                # 审批 thread 保留供查看审批前快照，pending 保留到下次中断覆盖。
+                snapshot = await agent.aget_state(config)
+                messages = (snapshot.values or {}).get("messages", []) or []
+                query = await _last_human_query(messages)
+                response = "".join(full_response) if full_response else "抱歉，我无法理解您的请求。"
+                await sm.session_manager.add_message(session_id, user_id, query or "（未知问题）", response)
+                agent_result_holder["response"] = response
+            except Exception as e:
+                logger.error(f"【Agent恢复响应】Agent执行失败: {e}", exc_info=True)
+                agent_result_holder["error"] = str(e)
+            finally:
+                agent_done.set()
+
+        agent_task = asyncio.create_task(run_agent())
         try:
+            yield f"data: {json.dumps({'type': 'response', 'content': '', 'session_id': session_id}, ensure_ascii=False)}\n\n"
+            while not agent_done.is_set():
+                try:
+                    event = await asyncio.wait_for(thinking_queue.get(), timeout=0.1)
+                    yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+                    thinking_queue.task_done()
+                except TimeoutError:
+                    continue
+            while not thinking_queue.empty():
+                try:
+                    event = thinking_queue.get_nowait()
+                    yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+                    thinking_queue.task_done()
+                except asyncio.QueueEmpty:
+                    break
             await agent_task
-        except asyncio.CancelledError:
-            pass
 
-        error_message = f"错误: {str(e)}"
-        yield f"data: {json.dumps({'type': 'error', 'content': error_message, 'session_id': session_id}, ensure_ascii=False)}\n\n"
-        yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"
+            if agent_result_holder.get("interrupt"):
+                payload = agent_result_holder["interrupt"]
+                yield f"data: {json.dumps({'type': 'interrupt', **payload, 'session_id': session_id}, ensure_ascii=False)}\n\n"
+                return
+            if agent_result_holder.get("error"):
+                yield f"data: {json.dumps({'type': 'error', 'content': agent_result_holder['error'], 'session_id': session_id}, ensure_ascii=False)}\n\n"
+                yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"
+                return
+            yield f"data: {json.dumps({'type': 'done', 'session_id': session_id}, ensure_ascii=False)}\n\n"
+        except Exception as e:
+            logger.error(f"【Agent恢复响应】处理请求失败: {e}", exc_info=True)
+            agent_task.cancel()
+            try:
+                await agent_task
+            except asyncio.CancelledError:
+                pass
+            yield f"data: {json.dumps({'type': 'error', 'content': f'错误: {str(e)}', 'session_id': session_id}, ensure_ascii=False)}\n\n"
+            yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"

--- a/backend/app/agent/agent_middleware.py
+++ b/backend/app/agent/agent_middleware.py
@@ -22,6 +22,7 @@ except ImportError:
 
 try:
     from langchain.agents.middleware import (
+        HumanInTheLoopMiddleware,
         ModelRetryMiddleware,
         ToolCallLimitMiddleware,
         ToolRetryMiddleware,
@@ -55,6 +56,7 @@ except ImportError:
     after_model = _fallback_middleware("after_model")
     wrap_model_call = _fallback_middleware("wrap_model_call")
     wrap_tool_call = _fallback_middleware("wrap_tool_call")
+    HumanInTheLoopMiddleware = None
     ModelRetryMiddleware = None
     ToolRetryMiddleware = None
     ToolCallLimitMiddleware = None
@@ -66,6 +68,23 @@ except ImportError:
 
 from app.agent.agent_tools import get_thinking_callback_from_context
 from app.core.logger_handler import logger
+
+def _describe_create_note(tool_call, state, runtime) -> str:
+    """创建笔记审批摘要：只带标题、正文长度与开头预览，避免把全文塞进审批负载。"""
+    args = (tool_call.get("args") if isinstance(tool_call, dict) else {}) or {}
+    title = args.get("title") or "(无标题)"
+    content = args.get("content") or ""
+    preview = content[:120]
+    suffix = "…" if len(content) > 120 else ""
+    return f"将创建笔记《{title}》（正文约 {len(content)} 字）：{preview}{suffix}"
+
+DEFAULT_APPROVAL_TOOLS: dict = {
+    "create_note_tool": {
+        "allowed_decisions": ["approve", "reject"],
+        "description": _describe_create_note,
+    },
+}
+
 
 SLOW_MODEL_CALL_MS = 5000
 TOOL_ARGS_LOG_LIMIT = 200
@@ -171,8 +190,11 @@ async def tool_call_hook(request, handler):
     return response
 
 
-def get_middleware():
-    """返回本模块的所有中间件（自定义钩子 + 官方健壮性中间件）。"""
+def get_middleware(approval_tools: dict | None = None):
+    """返回本模块的所有中间件（自定义钩子 + 官方健壮性中间件 + HITL 审批中间件）。
+
+    approval_tools: {工具名: {"allowed_decisions": [...]}}；None 使用默认白名单。
+    """
     middleware = [
         log_before_agent,
         log_after_agent,
@@ -187,4 +209,13 @@ def get_middleware():
             ToolRetryMiddleware(max_retries=1),
             ToolCallLimitMiddleware(run_limit=5),
         ]
+    if HumanInTheLoopMiddleware is not None:
+        middleware.append(
+            HumanInTheLoopMiddleware(
+                interrupt_on=approval_tools or DEFAULT_APPROVAL_TOOLS,
+                description_prefix="工具执行需要你的确认",
+            )
+        )
+    else:
+        logger.warning("HumanInTheLoopMiddleware 不可用，审批中间件已禁用（降级模式）。")
     return middleware

--- a/backend/app/agent/checkpoint/mysql_saver.py
+++ b/backend/app/agent/checkpoint/mysql_saver.py
@@ -1,0 +1,315 @@
+"""MySQL Checkpointer：LangGraph BaseCheckpointSaver 的 SQLAlchemy/MySQL 实现。
+
+以官方 langgraph checkpoint sqlite aio 版为蓝本移植，适配：
+- 通过注入的 session_factory 执行（生产 AsyncSessionLocal=MySQL，测试=SQLite）；
+- upsert 方言分支：mysql 用 ON DUPLICATE KEY UPDATE / INSERT IGNORE，
+  sqlite 用 INSERT OR REPLACE / INSERT OR IGNORE（首次使用时探测并缓存）。
+
+序列化统一走 JsonPlusSerializer（可编码 BaseMessage）。
+注意：SQL 一律用 SQLAlchemy text() 的 :name 命名绑定（由引擎按方言编译为 %s / ?），
+切勿手写 %s / ? 占位符。
+"""
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    WRITES_IDX_MAP,
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    get_checkpoint_id,
+    get_checkpoint_metadata,
+)
+from sqlalchemy import text
+
+_CHECKPOINT_COLS = (
+    "thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, "
+    "type, checkpoint, metadata"
+)
+
+
+class MySQLCheckpointSaver(BaseCheckpointSaver):
+    """把 LangGraph checkpoint 存到 SQLAlchemy 会话背后的库（MySQL/测试 SQLite）。"""
+
+    def __init__(self, session_factory) -> None:
+        super().__init__()
+        self.session_factory = session_factory
+        self._dialect: str | None = None
+        self._dialect_lock = asyncio.Lock()
+
+    # ---- 方言探测（每个进程一次） ----
+    async def _dialect_name(self) -> str:
+        if self._dialect is not None:
+            return self._dialect
+        async with self._dialect_lock:
+            if self._dialect is not None:
+                return self._dialect
+            async with self.session_factory() as session:
+                self._dialect = session.get_bind().dialect.name
+        return self._dialect
+
+    # ---- SQL 模板（按方言分支） ----
+    async def _sql(self, *, upsert: bool) -> tuple[str, str]:
+        """返回 (checkpoints_sql, writes_sql) 两条 upsert 模板（参数为 :name 命名绑定）。"""
+        dialect = await self._dialect_name()
+        if dialect == "mysql":
+            cp = (
+                "INSERT INTO agent_checkpoints "
+                "(thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, "
+                "type, checkpoint, metadata) VALUES (:thread_id, :checkpoint_ns, :checkpoint_id, "
+                ":parent_checkpoint_id, :type, :checkpoint, :metadata) "
+                "ON DUPLICATE KEY UPDATE parent_checkpoint_id=VALUES(parent_checkpoint_id), "
+                "type=VALUES(type), checkpoint=VALUES(checkpoint), metadata=VALUES(metadata)"
+            )
+            wr = (
+                "INSERT INTO agent_checkpoint_writes "
+                "(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value) "
+                "VALUES (:thread_id, :checkpoint_ns, :checkpoint_id, :task_id, :idx, "
+                ":channel, :type, :value) "
+                "ON DUPLICATE KEY UPDATE channel=VALUES(channel), type=VALUES(type), value=VALUES(value)"
+                if upsert else
+                "INSERT IGNORE INTO agent_checkpoint_writes "
+                "(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value) "
+                "VALUES (:thread_id, :checkpoint_ns, :checkpoint_id, :task_id, :idx, "
+                ":channel, :type, :value)"
+            )
+        else:
+            cp = (
+                "INSERT OR REPLACE INTO agent_checkpoints "
+                "(thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, "
+                "type, checkpoint, metadata) VALUES (:thread_id, :checkpoint_ns, :checkpoint_id, "
+                ":parent_checkpoint_id, :type, :checkpoint, :metadata)"
+            )
+            wr = (
+                "INSERT OR REPLACE INTO agent_checkpoint_writes "
+                "(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value) "
+                "VALUES (:thread_id, :checkpoint_ns, :checkpoint_id, :task_id, :idx, "
+                ":channel, :type, :value)"
+                if upsert else
+                "INSERT OR IGNORE INTO agent_checkpoint_writes "
+                "(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value) "
+                "VALUES (:thread_id, :checkpoint_ns, :checkpoint_id, :task_id, :idx, "
+                ":channel, :type, :value)"
+            )
+        return cp, wr
+
+    # ---- langgraph 接口 ----
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        thread_id = str(config["configurable"]["thread_id"])
+        checkpoint_ns = str(config["configurable"].get("checkpoint_ns", ""))
+        checkpoint_id = get_checkpoint_id(config)
+
+        async with self.session_factory() as session:
+            if checkpoint_id:
+                rows = (
+                    await session.execute(
+                        text(
+                            f"SELECT {_CHECKPOINT_COLS} FROM agent_checkpoints "
+                            "WHERE thread_id=:tid AND checkpoint_ns=:ns AND checkpoint_id=:cid"
+                        ),
+                        {"tid": thread_id, "ns": checkpoint_ns, "cid": checkpoint_id},
+                    )
+                ).fetchall()
+            else:
+                rows = (
+                    await session.execute(
+                        text(
+                            f"SELECT {_CHECKPOINT_COLS} FROM agent_checkpoints "
+                            "WHERE thread_id=:tid AND checkpoint_ns=:ns "
+                            "ORDER BY checkpoint_id DESC LIMIT 1"
+                        ),
+                        {"tid": thread_id, "ns": checkpoint_ns},
+                    )
+                ).fetchall()
+            if not rows:
+                return None
+            row = rows[0]
+            tid, cid, parent_cid, type_, checkpoint, metadata = (
+                row[0], row[2], row[3], row[4], row[5], row[6],
+            )
+            if checkpoint_id is None:
+                config = {
+                    "configurable": {
+                        "thread_id": tid,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": cid,
+                    }
+                }
+            writes = (
+                await session.execute(
+                    text(
+                        "SELECT task_id, channel, type, value FROM agent_checkpoint_writes "
+                        "WHERE thread_id=:tid AND checkpoint_ns=:ns AND checkpoint_id=:cid "
+                        "ORDER BY task_id, idx"
+                    ),
+                    {"tid": tid, "ns": checkpoint_ns, "cid": str(config["configurable"]["checkpoint_id"])},
+                )
+            ).fetchall()
+
+        parent_config = None
+        if parent_cid:
+            parent_config = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": parent_cid,
+                }
+            }
+        return CheckpointTuple(
+            config,
+            self.serde.loads_typed((type_, checkpoint)),
+            cast(CheckpointMetadata, json.loads(metadata.decode("utf-8")) if metadata else {}),
+            parent_config,
+            [
+                (task_id, channel, self.serde.loads_typed((wtype, value)))
+                for task_id, channel, wtype, value in writes
+            ],
+        )
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        if config is None:
+            return
+        thread_id = str(config["configurable"]["thread_id"])
+        checkpoint_ns = str(config["configurable"].get("checkpoint_ns", ""))
+        where = "WHERE thread_id=:tid AND checkpoint_ns=:ns"
+        params: dict[str, Any] = {"tid": thread_id, "ns": checkpoint_ns}
+        if before and (bid := get_checkpoint_id(before)):
+            where += " AND checkpoint_id < :bid"
+            params["bid"] = bid
+        sql = (
+            f"SELECT {_CHECKPOINT_COLS} FROM agent_checkpoints {where} "
+            "ORDER BY checkpoint_id DESC"
+        )
+        if limit is not None:
+            sql += " LIMIT :lim"
+            params["lim"] = limit
+        async with self.session_factory() as session:
+            rows = (await session.execute(text(sql), params)).fetchall()
+            for row in rows:
+                tid, cid, parent_cid, type_, checkpoint, metadata = (
+                    row[0], row[2], row[3], row[4], row[5], row[6],
+                )
+                yield CheckpointTuple(
+                    {
+                        "configurable": {
+                            "thread_id": tid,
+                            "checkpoint_ns": checkpoint_ns,
+                            "checkpoint_id": cid,
+                        }
+                    },
+                    self.serde.loads_typed((type_, checkpoint)),
+                    cast(CheckpointMetadata, json.loads(metadata.decode("utf-8")) if metadata else {}),
+                    (
+                        {
+                            "configurable": {
+                                "thread_id": thread_id,
+                                "checkpoint_ns": checkpoint_ns,
+                                "checkpoint_id": parent_cid,
+                            }
+                        }
+                        if parent_cid else None
+                    ),
+                    [],
+                )
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        sql_cp, _ = await self._sql(upsert=True)
+        thread_id = str(config["configurable"]["thread_id"])
+        checkpoint_ns = str(config["configurable"].get("checkpoint_ns", ""))
+        type_, serialized = self.serde.dumps_typed(checkpoint)
+        serialized_metadata = json.dumps(
+            get_checkpoint_metadata(config, metadata), ensure_ascii=False
+        ).encode("utf-8", "ignore")
+        async with self.session_factory() as session:
+            await session.execute(
+                text(sql_cp),
+                {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": checkpoint["id"],
+                    "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
+                    "type": type_,
+                    "checkpoint": serialized,
+                    "metadata": serialized_metadata,
+                },
+            )
+            await session.commit()
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: list[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        upsert = all(w[0] in WRITES_IDX_MAP for w in writes)
+        _, sql_wr = await self._sql(upsert=upsert)
+        rows = [
+            (
+                str(config["configurable"]["thread_id"]),
+                str(config["configurable"].get("checkpoint_ns", "")),
+                str(config["configurable"]["checkpoint_id"]),
+                task_id,
+                WRITES_IDX_MAP.get(channel, idx),
+                channel,
+                *self.serde.dumps_typed(value),
+            )
+            for idx, (channel, value) in enumerate(writes)
+        ]
+        async with self.session_factory() as session:
+            for params in rows:
+                await session.execute(
+                    text(sql_wr),
+                    {
+                        "thread_id": params[0],
+                        "checkpoint_ns": params[1],
+                        "checkpoint_id": params[2],
+                        "task_id": params[3],
+                        "idx": params[4],
+                        "channel": params[5],
+                        "type": params[6],
+                        "value": params[7],
+                    },
+                )
+            await session.commit()
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        async with self.session_factory() as session:
+            await session.execute(
+                text(
+                    "DELETE FROM agent_checkpoints WHERE thread_id=:tid"
+                ),
+                {"tid": str(thread_id)},
+            )
+            await session.execute(
+                text(
+                    "DELETE FROM agent_checkpoint_writes WHERE thread_id=:tid"
+                ),
+                {"tid": str(thread_id)},
+            )
+            await session.commit()

--- a/backend/app/db/db_config.py
+++ b/backend/app/db/db_config.py
@@ -72,7 +72,10 @@ async def _migrate_columns(conn):
 # 初始化数据库，创建所有表
 async def init_db():
     # 确保所有 Model 已导入，注册到 Base.metadata
-    from app.models import chat_history, graph, note, note_template, review_record, user_model  # noqa: F401
+    from app.models import (
+        agent_checkpoint,  # noqa: F401
+        chat_history, graph, note, note_template, review_record, user_model,
+    )
 
     async with async_engine.begin() as conn:
         # 先删除旧表，然后创建新表

--- a/backend/app/models/agent_checkpoint.py
+++ b/backend/app/models/agent_checkpoint.py
@@ -1,0 +1,37 @@
+"""LangGraph checkpoint 持久化表（自定义 MySQL saver 用）。
+
+字段结构对齐官方 sqlite saver 的两张表：
+- agent_checkpoints：每个 superstep 的完整状态快照
+- agent_checkpoint_writes：任务中间写（含 interrupt/resume 特殊写）
+
+checkpoint 与 metadata 序列化为字节后存入 BLOB 列。
+"""
+from sqlalchemy import Column, Integer, LargeBinary, String
+from sqlalchemy.dialects.mysql import LONGBLOB
+
+from app.models.chat_history import Base
+
+
+class AgentCheckpoint(Base):
+    __tablename__ = "agent_checkpoints"
+
+    thread_id = Column(String(255), primary_key=True, index=True)
+    checkpoint_ns = Column(String(255), primary_key=True, default="")
+    checkpoint_id = Column(String(64), primary_key=True)
+    parent_checkpoint_id = Column(String(64), nullable=True)
+    type = Column(String(64), nullable=True)
+    checkpoint = Column(LargeBinary().with_variant(LONGBLOB(), "mysql"))
+    metadata_ = Column(LargeBinary().with_variant(LONGBLOB(), "mysql"), name="metadata")
+
+
+class AgentCheckpointWrite(Base):
+    __tablename__ = "agent_checkpoint_writes"
+
+    thread_id = Column(String(255), primary_key=True)
+    checkpoint_ns = Column(String(255), primary_key=True, default="")
+    checkpoint_id = Column(String(64), primary_key=True)
+    task_id = Column(String(64), primary_key=True)
+    idx = Column(Integer, primary_key=True)
+    channel = Column(String(255), nullable=False)
+    type = Column(String(64), nullable=True)
+    value = Column(LargeBinary().with_variant(LONGBLOB(), "mysql"))

--- a/backend/app/models/chat_history.py
+++ b/backend/app/models/chat_history.py
@@ -12,6 +12,7 @@ class ChatSession(Base):
     user_id = Column(String(64), index=True, nullable=False)
 
     title = Column(String(255), default="新的对话")
+    pending_run_id = Column(String(64), nullable=True, default=None)
     metadata_ = Column(JSON, name="metadata")  # metadata 是 SQL 保留字，加下划线
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/app/router/chat.py
+++ b/backend/app/router/chat.py
@@ -10,13 +10,22 @@ import uuid
 from fastapi import Depends
 from fastapi.responses import StreamingResponse
 from fastapi.routing import APIRouter
+from pydantic import BaseModel, Field
 
-from app.agent.agent import get_agent_stream_response
+from app.agent.agent import (
+    get_agent_resume_stream_response,
+    get_agent_stream_response,
+    read_approval_snapshot,
+    read_pending_interrupt,
+)
 from app.agent.agent_rag_tool import build_pre_searched_queries
+from app.agent.checkpoint.mysql_saver import MySQLCheckpointSaver
+from app.core.logger_handler import logger
 from app.core.rate_limit import rate_limit
 from app.core.success_response import success_response
 from app.rag.agentic_rag.service import AgenticRagService
 from app.schemas.models import QueryRequest, ReorderRequest, ReorderResponse, SessionResponse
+from app.services import session_manager as sm
 from app.utils.auth_utils import get_current_user_id
 
 chat_router = APIRouter(prefix="/chat", tags=["chat"])
@@ -103,16 +112,82 @@ async def query_stream(
     )
 
 
+class ResumeRequest(BaseModel):
+    """恢复审批请求模型"""
+    session_id: str
+    decisions: list[dict] = Field(default_factory=list)
+
+
+@chat_router.post("/agent/resume")
+async def resume_agent(
+        request: ResumeRequest,
+        user_id: str = Depends(get_current_user_id),
+        _: None = Depends(rate_limit(limit=10, window=60)),
+):
+    """恢复被中断的 Agent run（decisions: [{"type": "approve"|"reject", ...}]）"""
+    # run_id 从会话 pending_run_id 取（更稳，不信任客户端）
+    pending_run_id = await sm.session_manager.get_pending_run_id(request.session_id, user_id)
+    if not pending_run_id:
+        async def stream_error():
+            yield f"data: {json.dumps({'type': 'error', 'content': 'RESUME_MISMATCH'}, ensure_ascii=False)}\n\n"
+            yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"
+        return StreamingResponse(stream_error(), media_type="text/event-stream")
+
+    async def stream_resume():
+        async for chunk in get_agent_resume_stream_response(
+            session_id=request.session_id, user_id=user_id,
+            run_id=pending_run_id, decisions=request.decisions,
+        ):
+            yield chunk
+
+    return StreamingResponse(
+        stream_resume(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
+@chat_router.get("/session/{session_id}/pending")
+async def get_pending(session_id: str, user_id: str = Depends(get_current_user_id)):
+    """返回待审批中断元数据（含原始 query）；无 pending 返回 null。"""
+    pending_run_id = await sm.session_manager.get_pending_run_id(session_id, user_id)
+    if not pending_run_id:
+        return success_response(data=None)
+    info = await read_pending_interrupt(pending_run_id)
+    return success_response(data=info)
+
+
+@chat_router.get("/session/{session_id}/approval")
+async def get_approval(session_id: str, user_id: str = Depends(get_current_user_id)):
+    """返回该会话上次审批快照（含已审批完成，active=False）；从无审批返回 null。"""
+    pending_run_id = await sm.session_manager.get_pending_run_id(session_id, user_id)
+    if not pending_run_id:
+        return success_response(data=None)
+    info = await read_approval_snapshot(pending_run_id)
+    return success_response(data=info)
+
+
 @chat_router.get("/session/{session_id}", response_model=SessionResponse)
 async def get_session(session_id: str, user_id: str = Depends(get_current_user_id), router_service=Depends(get_router_service)):
     """获取会话信息，使用user_id验证"""
     history = await router_service.handle_get_session(session_id, user_id)
-    return success_response(data=SessionResponse(session_id=session_id, history=history))
+    pending_run_id = await router_service.handle_get_pending_run_id(session_id, user_id)
+    return success_response(data=SessionResponse(
+        session_id=session_id, history=history, pending_run_id=pending_run_id,
+    ))
 
 
 @chat_router.delete("/session/{session_id}")
 async def delete_session(session_id: str, user_id: str = Depends(get_current_user_id), router_service=Depends(get_router_service)):
-    """删除会话"""
+    """删除会话（若有待审批 run 一并清理 checkpoint thread）"""
+    from app.agent.agent import get_checkpointer
+
+    pending_run_id = await sm.session_manager.get_pending_run_id(session_id, user_id)
+    if pending_run_id:
+        try:
+            await get_checkpointer().adelete_thread(pending_run_id)
+        except Exception as e:
+            logger.warning(f"清理 pending thread 失败（可忽略）: {e}")
     await router_service.handle_delete_session(session_id, user_id)
     return success_response(message=f"Session {session_id} deleted successfully")
 

--- a/backend/app/router/chat_service.py
+++ b/backend/app/router/chat_service.py
@@ -17,6 +17,10 @@ class ChatService:
         history = await sm.session_manager.get_history(session_id, user_id)
         return history
 
+    async def handle_get_pending_run_id(self, session_id: str, user_id: str) -> str | None:
+        """处理获取会话待审批 run_id 逻辑"""
+        return await sm.session_manager.get_pending_run_id(session_id, user_id)
+
     async def handle_delete_session(self, session_id: str, user_id: str) -> None:
         """处理删除会话逻辑"""
         await sm.session_manager.clear_session(session_id, user_id)

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -12,6 +12,7 @@ class SessionResponse(BaseModel):
     """会话响应模型"""
     session_id: str
     history: list[tuple[str, str]]
+    pending_run_id: str | None = None
 
 
 class AgentStep(BaseModel):

--- a/backend/app/services/database_session_manager.py
+++ b/backend/app/services/database_session_manager.py
@@ -174,11 +174,37 @@ class DatabaseSessionManager:
                 {
                     "id": session.id,
                     "title": session.title,
+                    "pending_run_id": session.pending_run_id,
                     "created_at": session.created_at.isoformat() if session.created_at else None,
                     "updated_at": session.updated_at.isoformat() if session.updated_at else None
                 }
                 for session in sessions
             ]
+
+    async def get_pending_run_id(self, session_id: str, user_id: str) -> str | None:
+        """返回该会话待审批 run_id；无会话或不属于该用户返回 None。"""
+        async with AsyncSessionLocal() as db:
+            session = await db.run_sync(
+                lambda s: s.query(ChatSession)
+                .filter(ChatSession.id == session_id, ChatSession.user_id == user_id)
+                .first()
+            )
+            return session.pending_run_id if session else None
+
+    async def set_pending_run_id(
+        self, session_id: str, user_id: str, run_id: str | None
+    ) -> None:
+        """写入/清除会话的待审批 run_id（校验所有权）。"""
+        async with AsyncSessionLocal() as db:
+            session = await db.run_sync(
+                lambda s: s.query(ChatSession)
+                .filter(ChatSession.id == session_id, ChatSession.user_id == user_id)
+                .first()
+            )
+            if session is None:
+                return
+            session.pending_run_id = run_id
+            await db.commit()
 
 
 # 全局数据库会话管理器实例

--- a/backend/tests/agent/test_agent.py
+++ b/backend/tests/agent/test_agent.py
@@ -6,11 +6,14 @@ Level A（推荐）：monkeypatch `agent_factory.create_agent` 返回
 Level C（尽力而为的真端到端）：不 mock create_agent，给工厂注入一个
 能发出真实 tool_call AIMessage 的假模型，让 create_agent 真正调用一次工具。
 """
+import asyncio
 import json
+import types
 
 import pytest_asyncio
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_core.tools import tool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph.state import CompiledStateGraph
 from sqlalchemy import select
 
@@ -18,8 +21,10 @@ import app.services as services_module
 from app.agent import agent as agent_module
 from app.agent.agent import (
     AgentFactory,
+    _get_session_lock,
     get_agent,
     get_agent_response,
+    get_agent_resume_stream_response,
     get_agent_stream_response,
 )
 from app.agent.agent_rag_tool import search_rag
@@ -115,7 +120,7 @@ class RecordingAgent(FakeAgent):
 class BrokenAgent:
     """流式执行直接抛异常的替身 agent（async 生成器，异常在迭代时抛出）。"""
 
-    async def astream_events(self, inputs, version="v2"):
+    async def astream_events(self, inputs, version="v2", config=None):
         if False:  # pragma: no cover
             yield None
         raise RuntimeError("代理内部异常")
@@ -376,7 +381,7 @@ async def test_get_agent_stream_response_forwards_real_search_rag_callback(
         })()
 
     class SearchRagStreamingAgent(FakeAgent):
-        async def astream_events(self, inputs, version="v2"):
+        async def astream_events(self, inputs, version="v2", config=None):
             self.inputs.append(inputs)
             yield {
                 "event": "on_tool_start",
@@ -587,9 +592,416 @@ async def test_level_c_end_to_end_real_tool_calling(monkeypatch):
         AIMessage(content="我已经调用了工具，回答完毕。"),
     ])
     monkeypatch.setattr(agent_module.agent_factory, "_create_chat_model", lambda custom_model=None: model)
+    # 真图 + MemorySaver：不碰生产 MySQL saver（controller 授权）。
+    monkeypatch.setattr(agent_module, "get_checkpointer", lambda: MemorySaver())
 
     result = await get_agent_response("请确认工具调用链路", custom_tools=[echo_tool], user_id="u1")
 
     assert result["response"] == "我已经调用了工具，回答完毕。"
     assert calls == ["你好世界"]  # 真实工具确实被执行
     assert any(step["tool"] == "echo_tool" for step in result["steps"])
+
+
+# ---------------------------------------------------------------------------
+# Task 4: HITL 审批中间件与 checkpointer 透传
+# ---------------------------------------------------------------------------
+def test_factory_default_middleware_contains_hitl():
+    from langchain.agents.middleware import HumanInTheLoopMiddleware
+
+    factory = AgentFactory()
+    assert any(isinstance(m, HumanInTheLoopMiddleware) for m in factory.default_middleware)
+    assert factory.approval_tools["create_note_tool"]["allowed_decisions"] == ["approve", "reject"]
+
+
+async def test_factory_create_agent_passes_checkpointer(monkeypatch):
+    """create_agent 透传 checkpointer=get_checkpointer()。"""
+    from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+
+    class ToolCallingFakeModel(FakeMessagesListChatModel):
+        """按调用次序逐条返回预设消息（覆盖 bind_tools 默认 NotImplementedError）。"""
+
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+    seen = {}
+    from langchain.agents import create_agent as real_create_agent
+
+    def fake_create_agent(*args, **kwargs):
+        seen["checkpointer"] = kwargs.pop("checkpointer", None)
+        # 仍走真实 create_agent，仅拦截参数观察（模型用假模型避免连网）
+        return real_create_agent(*args, **kwargs)
+
+    monkeypatch.setattr("app.agent.agent.create_agent", fake_create_agent)
+    monkeypatch.setattr(agent_module.agent_factory, "_create_chat_model",
+                        lambda custom_model=None: ToolCallingFakeModel(
+                            responses=[AIMessage(content="ok")]))
+    monkeypatch.setattr(agent_module, "get_checkpointer", lambda: object())
+
+    factory = agent_module.AgentFactory()
+    agent = factory.create_agent(custom_tools=[])
+    assert seen["checkpointer"] is not None
+    assert isinstance(agent, CompiledStateGraph)
+
+
+# ---------------------------------------------------------------------------
+# Task 5: 流式编排中断检测 / resume / 清理
+# ---------------------------------------------------------------------------
+class InterruptingAgent(FakeAgent):
+    """astream_events 正常结束，但 aget_state 报告 __interrupt__。"""
+
+    def __init__(self, payload: dict | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self.interrupt_payload = payload or {
+            "action_requests": [{"name": "create_note_tool", "args": {"title": "t"}, "description": "x"}],
+            "review_configs": [{"action_name": "create_note_tool", "allowed_decisions": ["approve", "reject"]}],
+        }
+        self.deleted_threads = []
+
+    async def aget_state(self, config):
+        return types.SimpleNamespace(
+            next=("__interrupt__",),
+            values={"messages": self.messages},
+            interrupts=(types.SimpleNamespace(name="__interrupt__", value=self.interrupt_payload),),
+        )
+
+    async def adelete_thread(self, thread_id):
+        self.deleted_threads.append(thread_id)
+
+
+async def test_stream_interrupt_emits_interrupt_frame_and_sets_pending(
+    monkeypatch, patched_db, fresh_session_manager
+):
+    agent = InterruptingAgent(messages=[AIMessage(content="")])
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: agent)
+    fake_saver = types.SimpleNamespace(adelete_thread=agent.adelete_thread)
+    monkeypatch.setattr(agent_module, "get_checkpointer", lambda: fake_saver)
+
+    frames = await _collect_stream("帮我记个笔记", session_id="s1", user_id="u1")
+    events = _parse_frames(frames)
+    interrupts = [e for e in events if e["type"] == "interrupt"]
+    assert len(interrupts) == 1
+    assert interrupts[0]["run_id"]
+    assert interrupts[0]["payload"]["action_requests"][0]["name"] == "create_note_tool"
+    assert events[-1]["type"] == "interrupt"  # 中断帧收尾，无 done 帧
+    # 不写 ChatMessage 镜像
+    async with patched_db() as db:
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+    assert msgs == []
+    # pending_run_id 已写
+    async with patched_db() as db:
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one()
+    assert sess.pending_run_id is not None
+    assert agent.deleted_threads == []  # 中断不删 thread
+
+
+async def test_stream_interrupt_pending_guard_rejects_new_query(
+    monkeypatch, patched_db, fresh_session_manager
+):
+    fake = FakeAgent(events=_agent_run_events(final=["不该执行"]))
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: fake)
+    # 先埋一个 pending
+    async with patched_db() as db:
+        db.add(ChatSession(id="s1", user_id="u1", pending_run_id="run-old"))
+        await db.commit()
+
+    frames = await _collect_stream("新问题", session_id="s1", user_id="u1")
+    events = _parse_frames(frames)
+    errors = [e for e in events if e["type"] == "error"]
+    assert errors and errors[0]["content"].startswith("PENDING_EXISTS")
+
+
+async def test_resume_completes_and_retains_thread(
+    monkeypatch, patched_db, fresh_session_manager
+):
+    response_text = "已创建笔记"
+    fake = FakeAgent(messages=[
+        HumanMessage(content="帮我记个笔记"),
+        AIMessage(content=response_text),
+    ], events=_agent_run_events(final=[response_text]))
+    fake.deleted = []
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: fake)
+    fake_saver = types.SimpleNamespace(adelete_thread=lambda tid: fake.deleted.append(tid))
+    monkeypatch.setattr(agent_module, "get_checkpointer", lambda: fake_saver)
+    async with patched_db() as db:
+        db.add(ChatSession(id="s1", user_id="u1", pending_run_id="run-1"))
+        await db.commit()
+
+    frames = []
+    async for f in get_agent_resume_stream_response(
+        session_id="s1", user_id="u1", run_id="run-1",
+        decisions=[{"type": "approve"}],
+    ):
+        frames.append(f)
+    events = _parse_frames(frames)
+    assert "".join(e["content"] for e in events if e["type"] == "response" and e["content"]) == response_text
+    assert events[-1]["type"] == "done"
+    # resume 输入是 Command(resume=...)（FakeAgent 记录 inputs[0] 为 Command 对象）
+    assert getattr(fake.inputs[0], "resume", None) == {"decisions": [{"type": "approve"}]}
+    # 镜像落库；审批 thread 与 pending 保留（供查看审批前快照）
+    async with patched_db() as db:
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one()
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+    assert sess.pending_run_id == "run-1"
+    assert [m.role for m in msgs] == ["user", "assistant"]
+    assert [m.content for m in msgs] == ["帮我记个笔记", response_text]
+    assert fake.deleted == []
+
+
+async def test_resume_completed_rerun_rejected(
+    monkeypatch, patched_db, fresh_session_manager
+):
+    """同一 run 审批完成后再次 resume：ALREADY_COMPLETED，不重复执行/落镜像。"""
+    fake = FakeAgent(messages=[AIMessage(content="不应执行")],
+                     events=_agent_run_events(final=["不应执行"]))
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: fake)
+    deleted: list[str] = []
+
+    async def _aget_tuple(config):
+        return types.SimpleNamespace(pending_writes=[])
+
+    async def _fake_delete(thread_id: str):
+        deleted.append(thread_id)
+
+    monkeypatch.setattr(agent_module, "get_checkpointer",
+                        lambda: types.SimpleNamespace(
+                            aget_tuple=_aget_tuple, adelete_thread=_fake_delete))
+    async with patched_db() as db:
+        db.add(ChatSession(id="s1", user_id="u1", pending_run_id="run-1"))
+        await db.commit()
+
+    frames = []
+    async for f in get_agent_resume_stream_response(
+        session_id="s1", user_id="u1", run_id="run-1",
+        decisions=[{"type": "approve"}],
+    ):
+        frames.append(f)
+    events = _parse_frames(frames)
+    errors = [e for e in events if e["type"] == "error"]
+    assert len(errors) == 1
+    assert errors[0]["content"] == "ALREADY_COMPLETED"
+    assert fake.inputs == []  # 图未被执行
+    async with patched_db() as db:
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one()
+    assert msgs == []
+    assert sess.pending_run_id == "run-1"
+    assert deleted == []
+
+
+async def test_stream_guard_allows_new_query_after_completed_approval(
+    monkeypatch, patched_db, fresh_session_manager
+):
+    """pending 指向已审批完成的 thread 时，新问题放行（pending 留待下次中断覆盖）。"""
+    fake = FakeAgent(messages=[AIMessage(content="新答复")],
+                     events=_agent_run_events(final=["新答复"]))
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: fake)
+    deleted: list[str] = []
+
+    async def _aget_tuple(config):
+        return types.SimpleNamespace(pending_writes=[])
+
+    async def _fake_delete(thread_id: str):
+        deleted.append(thread_id)
+
+    monkeypatch.setattr(agent_module, "get_checkpointer",
+                        lambda: types.SimpleNamespace(
+                            aget_tuple=_aget_tuple, adelete_thread=_fake_delete))
+    async with patched_db() as db:
+        db.add(ChatSession(id="s1", user_id="u1", pending_run_id="run-old"))
+        await db.commit()
+
+    frames = await _collect_stream("新问题", session_id="s1", user_id="u1")
+    events = _parse_frames(frames)
+    assert events[-1]["type"] == "done"
+    assert not [e for e in events if e["type"] == "error"]
+    async with patched_db() as db:
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one()
+    assert sess.pending_run_id == "run-old"  # 无新中断，不覆盖
+    assert "run-old" not in deleted  # 历史审批 thread 保留
+    assert len(deleted) == 1  # 仅删除本次新 run 的 thread
+
+
+# ---------------------------------------------------------------------------
+# Fix wave：Finding 1——错误/取消路径的孤儿清理
+# ---------------------------------------------------------------------------
+async def test_stream_error_cleans_up_thread_no_mirror_no_pending(
+    monkeypatch, patched_db, fresh_session_manager
+):
+    """首跑 agent 中途抛错：发 error 帧、无镜像、无 pending，且删除本 run thread。"""
+    deleted: list[str] = []
+
+    async def _fake_delete(thread_id: str):
+        deleted.append(thread_id)
+
+    monkeypatch.setattr(agent_module, "get_checkpointer",
+                        lambda: types.SimpleNamespace(adelete_thread=_fake_delete))
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: BrokenAgent())
+
+    frames = await _collect_stream("你好", session_id="s1", user_id="u1")
+    events = _parse_frames(frames)
+    errors = [e for e in events if e["type"] == "error"]
+    assert len(errors) == 1
+    assert "代理内部异常" in errors[0]["content"]
+    assert events[-1]["type"] == "done"
+
+    async with patched_db() as db:
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one_or_none()
+    assert msgs == []
+    assert sess is None or sess.pending_run_id is None
+    assert len(deleted) == 1  # run_id 由函数内生成，断言恰删一次
+
+
+async def test_resume_error_keeps_pending_and_thread(
+    monkeypatch, patched_db, fresh_session_manager
+):
+    """resume 跑抛错：发 error 帧、镜像不动、pending 保留原 run_id、不删 thread。"""
+    deleted: list[str] = []
+
+    async def _fake_delete(thread_id: str):
+        deleted.append(thread_id)
+
+    monkeypatch.setattr(agent_module, "get_checkpointer",
+                        lambda: types.SimpleNamespace(adelete_thread=_fake_delete))
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: BrokenAgent())
+    async with patched_db() as db:
+        db.add(ChatSession(id="s1", user_id="u1", pending_run_id="run-1"))
+        await db.commit()
+
+    frames = []
+    async for f in get_agent_resume_stream_response(
+        session_id="s1", user_id="u1", run_id="run-1",
+        decisions=[{"type": "approve"}],
+    ):
+        frames.append(f)
+    events = _parse_frames(frames)
+    errors = [e for e in events if e["type"] == "error"]
+    assert len(errors) == 1
+    assert "代理内部异常" in errors[0]["content"]
+
+    async with patched_db() as db:
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one()
+    assert msgs == []
+    assert sess.pending_run_id == "run-1"
+    assert deleted == []
+
+
+# ---------------------------------------------------------------------------
+# Fix wave：Finding 2——同会话并发锁
+# ---------------------------------------------------------------------------
+def test_session_lock_identity():
+    """同 (user, session) 返回同一锁；不同 session/不同 user 返回不同锁。"""
+    assert _get_session_lock("lock-u", "lock-s1") is _get_session_lock("lock-u", "lock-s1")
+    assert _get_session_lock("lock-u", "lock-s1") is not _get_session_lock("lock-u", "lock-s2")
+    assert _get_session_lock("lock-u", "lock-s1") is not _get_session_lock("lock-u2", "lock-s1")
+
+
+async def test_stream_same_session_serialized(monkeypatch, patched_db, fresh_session_manager):
+    """同会话两路并发首跑必须串行（起止标记不交错），以事件门控保证确定性。"""
+    markers: list[str] = []
+    release = asyncio.Event()
+    started = asyncio.Event()
+    counter = {"n": 0}
+
+    class SlowAgent(FakeAgent):
+        def __init__(self, idx: int):
+            super().__init__(events=[])
+            self.idx = idx
+
+        async def astream_events(self, inputs, version="v2", config=None):
+            self.inputs.append(inputs)
+            markers.append(f"start-{self.idx}")
+            started.set()
+            await release.wait()
+            markers.append(f"end-{self.idx}")
+            yield {
+                "event": "on_chat_model_stream",
+                "name": "FakeChatModel",
+                "data": {"chunk": AIMessage(content=f"R{self.idx}")},
+            }
+
+    def _factory(**kwargs):
+        counter["n"] += 1
+        return SlowAgent(counter["n"])
+
+    async def _noop_delete(thread_id: str):
+        return None
+
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", _factory)
+    monkeypatch.setattr(agent_module, "get_checkpointer",
+                        lambda: types.SimpleNamespace(adelete_thread=_noop_delete))
+
+    async def _collect(query: str):
+        return [f async for f in get_agent_stream_response(
+            query, session_id="s-serial-1", user_id="u-serial-1")]
+
+    t1 = asyncio.create_task(_collect("Q1"))
+    t2 = asyncio.create_task(_collect("Q2"))
+    # 等第一路真正起跑（事件门控，确定性）；再让出调度使第二路走完“尝试拿锁→阻塞”路径。
+    await started.wait()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert len([m for m in markers if m.startswith("start-")]) == 1
+    release.set()
+    r1, r2 = await asyncio.gather(t1, t2)
+
+    assert len(markers) == 4
+    assert markers[0].startswith("start-") and markers[1].startswith("end-")
+    assert markers[2].startswith("start-") and markers[3].startswith("end-")
+    assert markers[0].split("-")[1] == markers[1].split("-")[1]
+    assert markers[2].split("-")[1] == markers[3].split("-")[1]
+    for frames in (r1, r2):
+        assert _parse_frames(frames)[-1]["type"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# Fix wave：Finding 3——非流式 get_agent_response 的中断信号
+# ---------------------------------------------------------------------------
+async def test_get_agent_response_interrupt_signal(monkeypatch):
+    """白名单中断经非流式路径：interrupted/run_id 结构化信号，不删 thread，不抛错。"""
+    deleted: list[str] = []
+
+    async def _fake_delete(thread_id: str):
+        deleted.append(thread_id)
+
+    agent = InterruptingAgent(messages=[AIMessage(content="")])
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: agent)
+    monkeypatch.setattr(agent_module, "get_checkpointer",
+                        lambda: types.SimpleNamespace(adelete_thread=_fake_delete))
+
+    result = await get_agent_response("帮我记个笔记", user_id="u1")
+    assert result["interrupted"] is True
+    assert result["run_id"]
+    assert deleted == []
+    assert "审批" in result["response"]
+    assert "resume" in result["response"]
+
+
+async def test_get_agent_response_normal_still_cleans(monkeypatch):
+    """非中断路径不变：正常答复、删除一次性 thread、interrupted 为 falsy。"""
+    deleted: list[str] = []
+
+    async def _fake_delete(thread_id: str):
+        deleted.append(thread_id)
+
+    fake = FakeAgent(messages=[AIMessage(content="答复")])
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", lambda **kw: fake)
+    monkeypatch.setattr(agent_module, "get_checkpointer",
+                        lambda: types.SimpleNamespace(adelete_thread=_fake_delete))
+
+    result = await get_agent_response("你好", user_id="u1")
+    assert result["response"] == "答复"
+    assert not result.get("interrupted")
+    assert len(deleted) == 1

--- a/backend/tests/agent/test_agent_middleware.py
+++ b/backend/tests/agent/test_agent_middleware.py
@@ -14,7 +14,7 @@ from langchain.agents.middleware import ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage
 
 from app.agent import agent_middleware as mw_module
-from app.agent.agent_middleware import get_middleware
+from app.agent.agent_middleware import _describe_create_note, get_middleware
 from app.agent.agent_tools import set_thinking_callback
 
 
@@ -34,7 +34,7 @@ class FakeLogger:
 
 def test_get_middleware_returns_all_hooks_in_order():
     mw = get_middleware()
-    assert len(mw) == 9
+    assert len(mw) == 10
     assert [m.name for m in mw] == [
         "log_before_agent",
         "log_after_agent",
@@ -45,6 +45,7 @@ def test_get_middleware_returns_all_hooks_in_order():
         "ModelRetryMiddleware",
         "ToolRetryMiddleware",
         "ToolCallLimitMiddleware",
+        "HumanInTheLoopMiddleware",
     ]
 
 
@@ -187,3 +188,23 @@ def test_tool_call_hook_truncates_long_args(monkeypatch):
     result = asyncio.run(mw[5].awrap_tool_call(request, handler))
     assert result == "tool-output"
     assert any("search_notes_tool" in msg for msg in fake_logger.infos)
+
+
+def test_describe_create_note_truncates_long_content():
+    """创建笔记审批摘要：长正文只带标题、字数与 120 字预览，不含全文。"""
+    tool_call = {"name": "create_note_tool",
+                 "args": {"title": "t", "content": "正文" * 200}}
+    desc = _describe_create_note(tool_call, {}, object())
+    assert "《t》" in desc
+    assert "正文约 400 字" in desc
+    assert desc.endswith("…")
+    assert "正文" * 150 not in desc
+
+
+def test_describe_create_note_short_content_kept_whole():
+    """短正文完整保留，不加省略号；缺标题时给默认值。"""
+    desc = _describe_create_note(
+        {"name": "create_note_tool", "args": {"content": "hello"}}, {}, object())
+    assert "(无标题)" in desc
+    assert desc.endswith("hello")
+    assert "…" not in desc

--- a/backend/tests/agent/test_agent_rag_integration.py
+++ b/backend/tests/agent/test_agent_rag_integration.py
@@ -9,6 +9,7 @@
 import pytest
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage
+from langgraph.checkpoint.memory import MemorySaver
 
 from app.agent import agent as agent_module
 from app.agent.agent import get_agent_response
@@ -59,6 +60,8 @@ async def test_real_agent_calls_search_rag_once(monkeypatch):
         AIMessage(content="基于补充证据回答完成。"),
     ])
     monkeypatch.setattr(agent_module.agent_factory, "_create_chat_model", lambda custom_model=None: model)
+    # 真图 + MemorySaver：不碰生产 MySQL saver（controller 授权的超 brief 测试改动）。
+    monkeypatch.setattr(agent_module, "get_checkpointer", lambda: MemorySaver())
 
     result = await get_agent_response("原始问题", user_id="u1")
     assert result["response"] == "基于补充证据回答完成。"
@@ -90,6 +93,8 @@ async def test_real_agent_stops_after_covered_hint(monkeypatch):
             AIMessage(content="好的，停止检索。"),
         ])
         monkeypatch.setattr(agent_module.agent_factory, "_create_chat_model", lambda custom_model=None: model)
+        # 真图 + MemorySaver：不碰生产 MySQL saver（controller 授权的超 brief 测试改动）。
+        monkeypatch.setattr(agent_module, "get_checkpointer", lambda: MemorySaver())
         result = await get_agent_response("原问题", user_id="u1")
         assert calls == []
         assert any(step["tool"] == "search_rag" for step in result["steps"])

--- a/backend/tests/agent/test_agent_stream_integration.py
+++ b/backend/tests/agent/test_agent_stream_integration.py
@@ -1,0 +1,174 @@
+"""Level C：真实 create_agent + SQLite saver + 工具调用假模型的完整流式链路。
+
+验证：interrupt 帧 → resume(approve) → 工具真正执行 → done → 镜像落库；
+reject 后工具不执行。
+"""
+import json
+
+import pytest_asyncio
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, ToolCall
+from langchain_core.tools import tool
+from sqlalchemy import select
+
+import app.agent.agent as agent_module
+from app.agent.agent import (
+    get_agent_resume_stream_response,
+    get_agent_stream_response,
+    read_approval_snapshot,
+)
+from app.agent.checkpoint.mysql_saver import MySQLCheckpointSaver
+from app.models.chat_history import ChatMessage, ChatSession
+from tests.conftest import patch_session_factory
+
+TOOL_CALLS: list[tuple] = []
+
+
+@tool
+def create_note_tool(title: str, content: str = "") -> str:
+    """创建笔记（集成测试用真实工具）。"""
+    TOOL_CALLS.append(("create_note_tool", title))
+    return f"已创建 {title}"
+
+
+@tool
+def read_time_tool() -> str:
+    """读取时间（非白名单，自动放行）。"""
+    TOOL_CALLS.append(("read_time_tool",))
+    return "2026-09-07"
+
+
+class ToolCallingApprovalModel(FakeMessagesListChatModel):
+    """首轮 tool_call(create_note_tool)，恢复后第二轮最终答复。"""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+@pytest_asyncio.fixture
+async def real_agent_env(monkeypatch, session_factory):
+    """真实图 + SQLite 版 MySQL saver；工厂替换为真 create_agent。"""
+    patch_session_factory(monkeypatch, session_factory)
+    saver = MySQLCheckpointSaver(session_factory=session_factory)
+    monkeypatch.setattr(agent_module, "get_checkpointer", lambda: saver)
+
+    model = ToolCallingApprovalModel(responses=[
+        AIMessage(content="", tool_calls=[
+            ToolCall(id="call-1", name="create_note_tool", args={"title": "测试"}),
+        ]),
+        AIMessage(content="笔记创建成功"),
+    ])
+
+    def real_create_agent(custom_tools=None, custom_system_prompt=None, **kwargs):
+        return create_agent(
+            model,
+            custom_tools or [create_note_tool, read_time_tool],
+            system_prompt=custom_system_prompt,
+            middleware=[HumanInTheLoopMiddleware(interrupt_on={
+                "create_note_tool": {"allowed_decisions": ["approve", "reject"]},
+            })],
+            checkpointer=saver,
+        )
+
+    monkeypatch.setattr(agent_module.agent_factory, "create_agent", real_create_agent)
+    monkeypatch.setattr(agent_module.agent_factory, "default_system_prompt", "你是助手")
+    yield {"saver": saver, "session_factory": session_factory}
+
+
+async def _collect_stream(*args, **kwargs):
+    return [f async for f in get_agent_stream_response(*args, **kwargs)]
+
+
+def _parse(raw_frames):
+    return [json.loads(f[len("data: "):].rstrip("\n")) for f in raw_frames]
+
+
+async def test_stream_approve_full_flow(real_agent_env):
+    TOOL_CALLS.clear()
+    frames = await _collect_stream("帮我创建笔记《测试》", session_id="s1", user_id="u1")
+    events = _parse(frames)
+    interrupt_events = [e for e in events if e["type"] == "interrupt"]
+    assert len(interrupt_events) == 1
+    run_id = interrupt_events[0]["run_id"]
+    payload = interrupt_events[0]["payload"]
+    assert [a["name"] for a in payload["action_requests"]] == ["create_note_tool"]
+    assert TOOL_CALLS == []  # 未批准前工具绝不能执行
+    assert events[-1]["type"] == "interrupt"  # 无 done 帧，不落镜像
+
+    async with real_agent_env["session_factory"]() as db:
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one()
+        assert sess.pending_run_id == run_id
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+        assert msgs == []
+
+    resume_frames = []
+    async for frame in get_agent_resume_stream_response(
+        session_id="s1", user_id="u1", run_id=run_id,
+        decisions=[{"type": "approve"}],
+    ):
+        resume_frames.append(frame)
+    resume_events = _parse(resume_frames)
+    assert resume_events[-1]["type"] == "done"
+    assert TOOL_CALLS == [("create_note_tool", "测试")]
+
+    async with real_agent_env["session_factory"]() as db:
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s1"))).scalar_one()
+        assert sess.pending_run_id == run_id
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+        assert [m.role for m in msgs] == ["user", "assistant"]
+        assert [m.content for m in msgs] == ["帮我创建笔记《测试》", "笔记创建成功"]
+    # 审批 thread 被保留（供查看审批前快照），快照标记已完成
+    assert await real_agent_env["saver"].aget_tuple(
+        {"configurable": {"thread_id": run_id}}) is not None
+    snap = await read_approval_snapshot(run_id)
+    assert snap is not None
+    assert snap["active"] is False
+    assert snap["query"] == "帮我创建笔记《测试》"
+    assert [a["name"] for a in snap["payload"]["action_requests"]] == ["create_note_tool"]
+    # 同一 run 再次 resume → ALREADY_COMPLETED，不写重复镜像
+    resume2_frames = []
+    async for frame in get_agent_resume_stream_response(
+        session_id="s1", user_id="u1", run_id=run_id,
+        decisions=[{"type": "approve"}],
+    ):
+        resume2_frames.append(frame)
+    resume2_events = _parse(resume2_frames)
+    assert [e for e in resume2_events if e["type"] == "error"][0]["content"] == "ALREADY_COMPLETED"
+    assert TOOL_CALLS == [("create_note_tool", "测试")]
+    async with real_agent_env["session_factory"]() as db:
+        msgs = (await db.execute(
+            select(ChatMessage).where(ChatMessage.session_id == "s1"))).scalars().all()
+        assert len(msgs) == 2
+
+
+async def test_stream_reject_full_flow(real_agent_env):
+    TOOL_CALLS.clear()
+    frames = await _collect_stream("创建笔记", session_id="s2", user_id="u1")
+    interrupt_events = [e for e in _parse(frames) if e["type"] == "interrupt"]
+    assert len(interrupt_events) == 1
+    run_id = interrupt_events[0]["run_id"]
+
+    resume_frames = []
+    async for frame in get_agent_resume_stream_response(
+        session_id="s2", user_id="u1", run_id=run_id,
+        decisions=[{"type": "reject", "message": "不需要了"}],
+    ):
+        resume_frames.append(frame)
+    assert _parse(resume_frames)[-1]["type"] == "done"
+    assert TOOL_CALLS == []  # reject 后工具不执行
+
+    async with real_agent_env["session_factory"]() as db:
+        sess = (await db.execute(
+            select(ChatSession).where(ChatSession.id == "s2"))).scalar_one()
+        assert sess.pending_run_id == run_id
+    # reject 的审批 thread 同样保留，快照可查
+    assert await real_agent_env["saver"].aget_tuple(
+        {"configurable": {"thread_id": run_id}}) is not None
+    snap = await read_approval_snapshot(run_id)
+    assert snap is not None and snap["active"] is False

--- a/backend/tests/agent/test_hitl_behavior.py
+++ b/backend/tests/agent/test_hitl_behavior.py
@@ -1,0 +1,111 @@
+"""HumanInTheLoopMiddleware + create_agent + MemorySaver 的图层行为基线。
+
+spike 已验证的真实语义：
+- 只有 interrupt_on 白名单工具进入 action_requests；其余工具自动放行；
+- approve 后白名单与非白名单工具在同一轮一起执行；
+- reject 后白名单工具不执行，模型收到 status="error" 的 ToolMessage；
+- 假模型响应按调用次序逐条消费（两次独立 astream_events 各消费一条）。
+"""
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command
+
+EXECUTED: list[tuple] = []
+
+
+@tool
+def create_note_tool(title: str) -> str:
+    """创建笔记（白名单工具）。"""
+    EXECUTED.append(("create_note_tool", title))
+    return f"created {title}"
+
+
+@tool
+def read_time_tool() -> str:
+    """读取时间（非白名单工具，自动放行）。"""
+    EXECUTED.append(("read_time_tool",))
+    return "now"
+
+
+class ToolCallingFakeModel(FakeMessagesListChatModel):
+    """按调用次序逐条返回预设消息（覆盖 bind_tools 默认 NotImplementedError）。"""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+def _build(model, saver):
+    return create_agent(
+        model,
+        [create_note_tool, read_time_tool],
+        middleware=[HumanInTheLoopMiddleware(interrupt_on={
+            "create_note_tool": {"allowed_decisions": ["approve", "reject"]},
+        })],
+        checkpointer=saver,
+    )
+
+
+def _first_ai_tool_call_message():
+    return AIMessage(content="", tool_calls=[
+        ToolCall(id="c1", name="read_time_tool", args={}),
+        ToolCall(id="c2", name="create_note_tool", args={"title": "t"}),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_approve_executes_whitelist_and_auto_approved_tools():
+    EXECUTED.clear()
+    saver = MemorySaver()
+    model = ToolCallingFakeModel(responses=[
+        _first_ai_tool_call_message(),
+        AIMessage(content="approve final answer"),
+    ])
+    cfg = {"configurable": {"thread_id": "approve-case"}}
+
+    await _build(model, saver).ainvoke({"messages": [HumanMessage("hi")]}, cfg)
+    snap = await _build(model, saver).aget_state(cfg)
+    assert snap.next  # 执行在中断点挂起
+    assert len(snap.interrupts) == 1
+    reqs = snap.interrupts[0].value["action_requests"]
+    # 只有白名单工具被拦截；同批的 read_time_tool 不在其中
+    assert [r["name"] for r in reqs] == ["create_note_tool"]
+    assert EXECUTED == []  # 未批准前任何工具都不执行
+
+    await _build(model, saver).ainvoke(
+        Command(resume={"decisions": [{"type": "approve"}]}), cfg)
+    # 自动放行的 read_time 与批准的 create_note 同一轮执行
+    assert EXECUTED == [("read_time_tool",), ("create_note_tool", "t")]
+    last = (await _build(model, saver).aget_state(cfg)).values["messages"][-1]
+    assert last.content == "approve final answer"
+
+
+@pytest.mark.asyncio
+async def test_reject_skips_tool_and_delivers_error_tool_message():
+    EXECUTED.clear()
+    saver = MemorySaver()
+    model = ToolCallingFakeModel(responses=[
+        _first_ai_tool_call_message(),
+        AIMessage(content="reject final answer"),
+    ])
+    cfg = {"configurable": {"thread_id": "reject-case"}}
+
+    await _build(model, saver).ainvoke({"messages": [HumanMessage("hi")]}, cfg)
+    await _build(model, saver).ainvoke(
+        Command(resume={"decisions": [{"type": "reject", "message": "不需要"}]}),
+        cfg,
+    )
+    # create_note 被拒不执行；read_time 自动放行仍执行
+    assert EXECUTED == [("read_time_tool",)]
+
+    msgs = (await _build(model, saver).aget_state(cfg)).values["messages"]
+    error_msgs = [m for m in msgs
+                  if isinstance(m, ToolMessage) and m.status == "error"]
+    assert len(error_msgs) == 1
+    assert error_msgs[0].tool_call_id == "c2"
+    assert error_msgs[0].content == "不需要"
+    assert msgs[-1].content == "reject final answer"

--- a/backend/tests/agent/test_mysql_saver.py
+++ b/backend/tests/agent/test_mysql_saver.py
@@ -1,0 +1,99 @@
+"""MySQLCheckpointSaver 单测：注入 SQLite session_factory，验证 langgraph saver 语义。
+
+覆盖：aput/aget_tuple roundtrip、parent 链、aput_writes 与 pending_writes、
+alist 排序与 limit、adelete_thread、中断写(WRITES_IDX_MAP 下标)。
+"""
+import json
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langgraph.checkpoint.base import CheckpointTuple
+
+from app.agent.checkpoint.mysql_saver import MySQLCheckpointSaver
+
+
+def _config(thread_id: str, checkpoint_id: str | None = None) -> dict:
+    cfg = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    if checkpoint_id:
+        cfg["configurable"]["checkpoint_id"] = checkpoint_id
+    return cfg
+
+
+def _make_checkpoint(cid: str) -> dict:
+    return {
+        "v": 1,
+        "id": cid,
+        "ts": "2026-09-07T00:00:00+00:00",
+        "channel_values": {"messages": [HumanMessage(content="hi")]},
+        "channel_versions": {},
+        "versions_seen": {},
+        "pending_sends": [],
+        "updated_channels": None,
+    }
+
+
+@pytest.fixture
+def saver(session_factory):
+    return MySQLCheckpointSaver(session_factory)
+
+
+async def test_aput_aget_tuple_roundtrip(saver):
+    cfg = _config("thread-1")
+    saved = await saver.aput(cfg, _make_checkpoint("c1"), {"step": 0}, {})
+    assert saved["configurable"]["checkpoint_id"] == "c1"
+
+    tup = await saver.aget_tuple(_config("thread-1"))
+    assert isinstance(tup, CheckpointTuple)
+    assert tup.checkpoint["id"] == "c1"
+    assert tup.metadata["step"] == 0
+    assert tup.pending_writes is None or tup.pending_writes == []
+    # 反序列化后的消息可读
+    msgs = tup.checkpoint["channel_values"]["messages"]
+    assert msgs[0].content == "hi"
+
+
+async def test_aget_tuple_by_checkpoint_id_and_parent_chain(saver):
+    await saver.aput(_config("thread-1"), _make_checkpoint("c1"), {"step": 0}, {})
+    # 第二次写入以 c1 为父：config 携带 checkpoint_id=c1
+    await saver.aput(_config("thread-1", "c1"), _make_checkpoint("c2"), {"step": 1}, {})
+    tup = await saver.aget_tuple(_config("thread-1", "c2"))
+    assert tup.parent_config["configurable"]["checkpoint_id"] == "c1"
+
+
+async def test_aput_writes_roundtrip(saver):
+    await saver.aput(_config("thread-1"), _make_checkpoint("c1"), {"step": 0}, {})
+    cfg = _config("thread-1", "c1")
+    await saver.aput_writes(cfg, [("messages", HumanMessage(content="tool out"))], "task-1")
+
+    tup = await saver.aget_tuple(_config("thread-1", "c1"))
+    assert tup.pending_writes is not None
+    assert tup.pending_writes[0] == ("task-1", "messages", HumanMessage(content="tool out"))
+
+
+async def test_alist_newest_first_with_limit(saver):
+    for cid in ("c1", "c2", "c3"):
+        await saver.aput(_config("thread-1"), _make_checkpoint(cid), {"step": 0}, {})
+    rows = [t async for t in saver.alist(_config("thread-1"), limit=2)]
+    assert [r.checkpoint["id"] for r in rows] == ["c3", "c2"]
+
+
+async def test_adelete_thread_removes_checkpoints_and_writes(saver):
+    await saver.aput(_config("thread-1"), _make_checkpoint("c1"), {"step": 0}, {})
+    await saver.aput_writes(_config("thread-1", "c1"), [("messages", "x")], "task-1")
+    await saver.adelete_thread("thread-1")
+    assert await saver.aget_tuple(_config("thread-1")) is None
+    rows = [t async for t in saver.alist(_config("thread-1"))]
+    assert rows == []
+
+
+async def test_special_write_uses_writes_idx_map_index(saver):
+    """interrupt 类特殊写必须以 WRITES_IDX_MAP 负下标落库（langgraph 依赖）。"""
+    from langgraph.checkpoint.base import WRITES_IDX_MAP
+
+    await saver.aput(_config("thread-1"), _make_checkpoint("c1"), {"step": 0}, {})
+    cfg = _config("thread-1", "c1")
+    await saver.aput_writes(cfg, [("__interrupt__", ("node", {"decision": "ask"}))], "task-1")
+    # 以上走 REPLACE 分支（channel 在 WRITES_IDX_MAP 中）
+
+    tup = await saver.aget_tuple(_config("thread-1", "c1"))
+    assert tup.pending_writes[0][1] == "__interrupt__"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -88,7 +88,15 @@ async def db_engine(tmp_path):
     改用文件库 + 默认连接池后，每个 session 有独立连接，写操作可被其他连接看到（与生产一致）。
     """
     # 确保所有 Model 在 create_all 之前已注册到 Base.metadata
-    from app.models import chat_history, graph, note, note_template, review_record, user_model  # noqa: F401
+    from app.models import (  # noqa: F401
+        agent_checkpoint,
+        chat_history,
+        graph,
+        note,
+        note_template,
+        review_record,
+        user_model,
+    )
 
     db_file = tmp_path / "test.db"
     engine = create_async_engine(

--- a/backend/tests/fakes.py
+++ b/backend/tests/fakes.py
@@ -6,6 +6,7 @@
 import asyncio
 import fnmatch
 import itertools
+import types
 import uuid as uuidlib
 
 from langchain_core.documents import Document
@@ -141,11 +142,19 @@ class FakeAgent:
         self.events = events or []
         self.inputs = []
 
-    async def ainvoke(self, inputs: dict):
+    async def ainvoke(self, inputs: dict, config: dict | None = None):
         self.inputs.append(inputs)
         return {"messages": self.messages}
 
-    async def astream_events(self, inputs: dict, version: str = "v2"):
+    async def astream_events(self, inputs, version: str = "v2", config: dict | None = None):
         self.inputs.append(inputs)
         for event in self.events:
             yield event
+
+    async def aget_state(self, config: dict):
+        """编排层在 run 结束后检测中断点：默认无中断（next 为空）。"""
+        return types.SimpleNamespace(
+            next=(),
+            values={"messages": self.messages},
+            interrupts=(),
+        )

--- a/backend/tests/services/test_database_session_manager.py
+++ b/backend/tests/services/test_database_session_manager.py
@@ -210,3 +210,20 @@ async def test_get_user_sessions_ordered_by_updated_at_desc(mgr, session_factory
     assert sessions[0]["title"] == "最新"
     assert sessions[0]["updated_at"] is not None
     assert sessions[0]["created_at"] is not None
+
+
+async def test_set_and_get_pending_run_id(session_factory, monkeypatch):
+    from tests.conftest import patch_session_factory
+
+    patch_session_factory(monkeypatch, session_factory)
+    from app.services import session_manager as sm
+    from app.services.database_session_manager import DatabaseSessionManager
+
+    mgr = DatabaseSessionManager()
+    await mgr.get_session("s-pending", "u1")  # 建会话
+    assert await mgr.get_pending_run_id("s-pending", "u1") is None
+    await mgr.set_pending_run_id("s-pending", "u1", "run-x")
+    assert await mgr.get_pending_run_id("s-pending", "u1") == "run-x"
+    await mgr.set_pending_run_id("s-pending", "u1", None)
+    assert await mgr.get_pending_run_id("s-pending", "u1") is None
+    assert await mgr.get_pending_run_id("s-pending", "other-user") is None

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -26,6 +26,9 @@ class FakeChatService:
     async def handle_get_session(self, session_id, user_id):
         return [("你好", "你好呀")]
 
+    async def handle_get_pending_run_id(self, session_id, user_id):
+        return None
+
     async def handle_delete_session(self, session_id, user_id):
         self.calls.append(("delete", session_id, user_id))
 
@@ -64,6 +67,34 @@ async def test_get_session(client, monkeypatch):
     body = resp.json()
     assert body["data"]["session_id"] == "abc"
     assert body["data"]["history"] == [["你好", "你好呀"]]
+    assert body["data"]["pending_run_id"] is None
+
+
+async def test_get_session_includes_pending_run_id(client, monkeypatch):
+    """会话详情响应携带 pending_run_id（供前端恢复审批卡）。"""
+    from main import app
+
+    import app.router.chat as chat_module
+
+    class FakeService:
+        def __init__(self):
+            self.calls = []
+
+        async def handle_get_session(self, session_id, user_id):
+            return [("q", "a")]
+
+        async def handle_get_pending_run_id(self, session_id, user_id):
+            self.calls.append((session_id, user_id))
+            return "run-9"
+
+    # 说明：brief 原文用 monkeypatch.setattr("app.router.chat.get_router_service", ...)
+    # 但 get_session 的 Depends 在装饰时已捕获原函数对象，setattr 无法生效；
+    # 此处沿用本文件既有 dependency_overrides 模式，断言意图与 brief 一致。
+    service = FakeService()
+    app.dependency_overrides[chat_module.get_router_service] = lambda: service
+    resp = await client.get("/chat/session/abc", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["pending_run_id"] == "run-9"
 
 
 async def test_delete_session(client, monkeypatch):
@@ -279,3 +310,41 @@ async def test_agent_query_stream_emits_thinking_before_rag_finishes(monkeypatch
 
     rag_finished.set()
     assert await asyncio.wait_for(_next_stream_chunk(response), timeout=0.2) == "agent response"
+
+
+async def test_resume_endpoint_returns_error_when_no_pending(client, monkeypatch):
+    from app.router import chat as chat_module
+
+    async def fake_resume(session_id, user_id, run_id, decisions, **kwargs):
+        yield f"data: {json.dumps({'type': 'error', 'content': 'RESUME_MISMATCH'}, ensure_ascii=False)}\n\n"
+        yield f"data: {json.dumps({'type': 'done'}, ensure_ascii=False)}\n\n"
+
+    monkeypatch.setattr(chat_module, "get_agent_resume_stream_response", fake_resume)
+    resp = await client.post("/chat/agent/resume", json={"session_id": "none", "decisions": [{"type": "approve"}]})
+    assert resp.status_code == 200
+    body = resp.text
+    assert "RESUME_MISMATCH" in body
+
+
+async def test_pending_endpoint_with_pending(client, monkeypatch):
+    from app.router import chat as chat_module
+
+    # 说明：brief 原文用同步 lambda，但路由以 await 调用两者，
+    # 同步替身会被 await 抛 TypeError；此处改用异步替身，断言意图与 brief 一致。
+    async def fake_get_pending_run_id(session_id, user_id):
+        return "run-7"
+
+    async def fake_read_pending_interrupt(run_id):
+        return {"run_id": "run-7", "payload": {"action_requests": []}, "query": "q"}
+
+    monkeypatch.setattr(
+        chat_module.sm.session_manager, "get_pending_run_id",
+        fake_get_pending_run_id,
+    )
+    monkeypatch.setattr(
+        chat_module, "read_pending_interrupt",
+        fake_read_pending_interrupt,
+    )
+    resp = await client.get("/chat/session/abc/pending", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["run_id"] == "run-7"

--- a/backend/tests/test_models_orm.py
+++ b/backend/tests/test_models_orm.py
@@ -142,6 +142,40 @@ class TestChatModels:
             await db_session.flush()
 
 
+class TestAgentCheckpointModels:
+    async def test_agent_checkpoint_roundtrip(self, db_session):
+        from app.models.agent_checkpoint import AgentCheckpoint
+
+        row = AgentCheckpoint(
+            thread_id="t1",
+            checkpoint_ns="",
+            checkpoint_id="c1",
+            parent_checkpoint_id=None,
+            type="checkpoint",
+            checkpoint=b"\x00\x01blob",
+            metadata_=b'{"step": 0}',
+        )
+        db_session.add(row)
+        await db_session.flush()
+        got = await db_session.get(AgentCheckpoint, ("t1", "", "c1"))
+        assert got.checkpoint == b"\x00\x01blob"
+
+    async def test_agent_checkpoint_write_roundtrip(self, db_session):
+        from app.models.agent_checkpoint import AgentCheckpointWrite
+
+        row = AgentCheckpointWrite(
+            thread_id="t1", checkpoint_ns="", checkpoint_id="c1",
+            task_id="task-1", idx=0, channel="messages", type="value",
+            value=b"payload",
+        )
+        db_session.add(row)
+        await db_session.flush()
+        got = await db_session.get(
+            AgentCheckpointWrite, ("t1", "", "c1", "task-1", 0)
+        )
+        assert got.channel == "messages"
+
+
 class TestNoteModel:
     async def test_defaults_applied(self, db_session):
         note = Note(id="note-1", user_id="u1", title="标题", content="内容")

--- a/front/src/api/endpoints.ts
+++ b/front/src/api/endpoints.ts
@@ -12,6 +12,8 @@ export const endpoints = {
 
   // AI Chat
   agentQueryStream: '/chat/agent/query/stream',
+  agentResume: '/chat/agent/resume',
+  getSessionPending: (id: string) => `/chat/session/${id}/pending`,
 
   // Sessions
   getSession: (id: string) => `/chat/session/${id}`,

--- a/front/src/api/sessions.ts
+++ b/front/src/api/sessions.ts
@@ -1,6 +1,6 @@
 import client from './client'
 import { endpoints } from './endpoints'
-import type { ApiResponse, ChatSession } from '../types/api'
+import type { ApiResponse, ApprovalPayload, ChatSession } from '../types/api'
 
 interface SessionsData {
   sessions: ChatSession[]
@@ -9,6 +9,13 @@ interface SessionsData {
 interface SessionDetailData {
   session_id: string
   history: [string, string][]
+  pending_run_id?: string | null
+}
+
+interface PendingData {
+  run_id: string
+  payload: ApprovalPayload
+  query?: string
 }
 
 export const sessionsApi = {
@@ -19,6 +26,11 @@ export const sessionsApi = {
 
   get: async (id: string) => {
     const res = await client.get<ApiResponse<SessionDetailData>>(endpoints.getSession(id))
+    return res.data
+  },
+
+  getPending: async (id: string) => {
+    const res = await client.get<ApiResponse<PendingData | null>>(endpoints.getSessionPending(id))
     return res.data
   },
 

--- a/front/src/hooks/useSSE.ts
+++ b/front/src/hooks/useSSE.ts
@@ -7,6 +7,7 @@ type SSECallback = {
   onResponse?: (content: string, sessionId?: string) => void
   onDone?: (sessionId?: string) => void
   onError?: (error: string) => void
+  onInterrupt?: (msg: SSEMessage) => void
   onKnowledgeProgress?: (data: KnowledgeSSEMessage) => void
 }
 
@@ -105,6 +106,10 @@ export function useSSE() {
                     flushResponse()
                     callbacks.onError?.(msg.content || 'Unknown error')
                     setError(msg.content || 'Unknown error')
+                    break
+                  case 'interrupt':
+                    flushResponse()
+                    callbacks.onInterrupt?.(msg)
                     break
                 }
               } catch {

--- a/front/src/pages/AIChat.tsx
+++ b/front/src/pages/AIChat.tsx
@@ -9,6 +9,8 @@ import remarkGfm from 'remark-gfm'
 import { useSSE } from '../hooks/useSSE'
 import { sessionsApi } from '../api/sessions'
 import { useThemeStore } from '../stores/useThemeStore'
+import { endpoints } from '../api/endpoints'
+import type { ApprovalPayload, SSEMessage } from '../types/api'
 import { isEvidenceEvent, isReadableRetrievalStatus, isRetrievalStage, isVisibleThinkingStage, mergeThinkingStep, previewEvidence, retrievalStatusLabel, toEvidence } from '../utils/thinkingTrace'
 import type { ThinkingStep } from '../utils/thinkingTrace'
 
@@ -38,17 +40,54 @@ const retrievalToolLabels: Record<string, string> = {
   web_search: 'Web 检索',
 }
 
+const approvalToolLabels: Record<string, string> = {
+  create_note_tool: '创建笔记',
+}
+
+const APPROVAL_PREVIEW_LIMIT = 240
+const APPROVAL_ARG_LIMIT = 200
+
+function truncateText(text: string, limit: number): string {
+  if (text.length <= limit) return text
+  return `${text.slice(0, limit)}…`
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/```[^\n]*\n?/g, '')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^>\s?/gm, '')
+    .replace(/^\s*(?:[-*+]|\d+[.)])\s+/gm, '')
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/^---+\s*$/gm, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .join('\n')
+}
+
 export default function AIChat() {
   const { sessionId } = useParams()
   const navigate = useNavigate()
   const { t } = useTranslation()
   const theme = useThemeStore((s) => s.theme)
   const { start, loading } = useSSE()
+  const [pendingApproval, setPendingApproval] = useState<{
+    runId: string
+    payload: ApprovalPayload
+    sessionId: string | null
+  } | null>(null)
+  const [approveSubmitting, setApproveSubmitting] = useState(false)
+  const [rejectReason, setRejectReason] = useState('')
   const [input, setInput] = useState('')
   const [messages, setMessages] = useState<Message[]>([])
   const [currentThinking, setCurrentThinking] = useState('')
   const [thinkingSteps, setThinkingSteps] = useState<ThinkingStep[]>([])
   const [expandedEvidence, setExpandedEvidence] = useState<Record<string, boolean>>({})
+  const [expandedApproval, setExpandedApproval] = useState<Record<string, boolean>>({})
   const [showThinking, setShowThinking] = useState(true)
   const [loadingHistory, setLoadingHistory] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -121,20 +160,49 @@ export default function AIChat() {
     }
   }, [cancelPendingThinking])
 
+  const fetchPendingApproval = useCallback(async () => {
+    // 新会话 URL 可能没有 :sessionId 参数，用流里见过的会话 id 兜底
+    const sid = sessionId ?? sessionStorage.getItem('lastSessionId')
+    if (!sid) return
+    try {
+      const res = await sessionsApi.getPending(sid)
+      const data = res.data as {
+        run_id?: string
+        payload?: ApprovalPayload
+        query?: string
+      } | null
+      if (data?.run_id && data?.payload) {
+        setPendingApproval({ runId: data.run_id, payload: data.payload, sessionId: sid })
+        if (data.query) {
+          setMessages((prev) => [...prev, { role: 'user', content: data.query ?? '' }])
+        }
+      } else {
+        setPendingApproval(null)
+      }
+    } catch {
+      // 静默失败：用户仍可重发消息触发后端守卫提示
+    }
+  }, [sessionId])
+
   useEffect(() => {
     if (sessionId) {
+      setPendingApproval(null)
+      setRejectReason('')
       setLoadingHistory(true)
       sessionsApi.get(sessionId).then((res) => {
-        const data = res.data as { history?: [string, string][] } | undefined
+        const data = res.data as { history?: [string, string][]; pending_run_id?: string | null } | undefined
         if (data?.history) {
           setMessages(data.history.flatMap(([query, response]) => [
             { role: 'user', content: query },
             { role: 'assistant', content: response },
           ]))
         }
+        if (data?.pending_run_id) {
+          fetchPendingApproval()
+        }
       }).catch(() => {}).finally(() => setLoadingHistory(false))
     }
-  }, [sessionId])
+  }, [sessionId, fetchPendingApproval])
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -150,7 +218,7 @@ export default function AIChat() {
   }, [sessionId, navigate])
 
   const handleSend = useCallback(async (query: string) => {
-    if (!query.trim() || loading) return
+    if (!query.trim() || loading || pendingApproval) return
 
     const userMsg: Message = { role: 'user', content: query }
     cancelPendingThinking()
@@ -240,6 +308,11 @@ export default function AIChat() {
             })
           }
         },
+        onInterrupt: (msg: SSEMessage) => {
+          if (!msg.run_id || !msg.payload) return
+          // interrupt 帧自带 session_id：新会话 URL 无参数时靠它恢复审批
+          setPendingApproval({ runId: msg.run_id, payload: msg.payload, sessionId: msg.session_id ?? null })
+        },
         onDone: (newSessionId) => {
           if (thinkingGenerationRef.current !== requestGeneration || thinkingTerminalGenerationRef.current === requestGeneration) return
           if (rafRef.current !== null) {
@@ -262,6 +335,11 @@ export default function AIChat() {
         },
         onError: (error) => {
           if (thinkingGenerationRef.current !== requestGeneration || thinkingTerminalGenerationRef.current === requestGeneration) return
+          if (error === 'PENDING_EXISTS' && sessionId) {
+            // 会话尚有未决审批：拉取 pending 恢复审批卡，不显示错误气泡
+            fetchPendingApproval()
+            return
+          }
           const pending = pendingThinkingRef.current.splice(0)
           if (pending.length > 0) {
             setThinkingSteps((prev) => pending.reduce(mergeIncomingThinkingStep, prev))
@@ -276,7 +354,83 @@ export default function AIChat() {
         },
       }
     )
-  }, [loading, sessionId, start, navigate, flushContent, cancelPendingThinking])
+  }, [loading, sessionId, start, navigate, flushContent, cancelPendingThinking, pendingApproval, fetchPendingApproval])
+
+  const handleApprove = async () => {
+    if (!pendingApproval || approveSubmitting) return
+    await resolveApproval([{ type: 'approve' }])
+  }
+
+  const handleReject = async () => {
+    if (!pendingApproval || approveSubmitting) return
+    await resolveApproval([{ type: 'reject', message: rejectReason.trim() || '用户拒绝了该操作' }])
+    setRejectReason('')
+  }
+
+  const resolveApproval = async (decisions: Array<Record<string, unknown>>) => {
+    if (!pendingApproval) return
+    // session_id 多级兜底：审批卡自带的 > URL 参数 > 流里见过的（新会话 URL 无参数时前两者都可能为空）
+    const sid = pendingApproval.sessionId ?? sessionId ?? sessionStorage.getItem('lastSessionId')
+    if (!sid) {
+      setMessages((prev) => [...prev, { role: 'assistant', content: 'Error: 无法确定会话，请刷新页面后重试' }])
+      return
+    }
+    setApproveSubmitting(true)
+    contentRef.current = ''
+    const requestGeneration = thinkingGenerationRef.current
+    thinkingManuallyCollapsedRef.current = false
+    setShowThinking(true)
+    try {
+      await start(
+        endpoints.agentResume,
+        { session_id: sid, decisions },
+        {
+          onThinking: (stage, content, details) => {
+            if (thinkingGenerationRef.current !== requestGeneration) return
+            if (!isVisibleThinkingStage(stage)) return
+            if (!thinkingManuallyCollapsedRef.current) setShowThinking(true)
+            const step: ThinkingStep = {
+              stage, content: content || '', details,
+            }
+            setThinkingSteps((prev) => mergeIncomingThinkingStep(prev, step))
+          },
+          onResponse: (content) => {
+            if (thinkingGenerationRef.current !== requestGeneration) return
+            contentRef.current += content
+            if (rafRef.current === null) {
+              rafRef.current = requestAnimationFrame(() => {
+                rafRef.current = null
+                if (thinkingGenerationRef.current !== requestGeneration) return
+                flushContent()
+              })
+            }
+          },
+          onInterrupt: (msg) => {
+            if (!msg.run_id || !msg.payload) return
+            setPendingApproval({ runId: msg.run_id, payload: msg.payload, sessionId: msg.session_id ?? null })
+          },
+          onDone: () => {
+            if (rafRef.current !== null) {
+              cancelAnimationFrame(rafRef.current)
+              rafRef.current = null
+            }
+            flushContent()
+            cancelPendingThinking()
+            setShowThinking(false)
+            setPendingApproval(null)
+            setApproveSubmitting(false)
+          },
+          onError: (error) => {
+            setPendingApproval(null)
+            setApproveSubmitting(false)
+            setMessages((prev) => [...prev, { role: 'assistant', content: `Error: ${error}` }])
+          },
+        },
+      )
+    } finally {
+      setApproveSubmitting(false)
+    }
+  }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -496,6 +650,117 @@ export default function AIChat() {
         </div>
       </div>
 
+      {pendingApproval && (
+        <div className="max-w-3xl mx-auto px-6 pt-4">
+          <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4 space-y-3">
+            <div className="text-sm font-medium text-[var(--color-text)]">
+              需要确认以下操作
+            </div>
+            {pendingApproval.payload.action_requests.map((req, i) => {
+              const expandKey = `${pendingApproval.runId}:${i}`
+              const expanded = expandedApproval[expandKey] === true
+              const toggleExpanded = () => setExpandedApproval((prev) => ({ ...prev, [expandKey]: !expanded }))
+              const args = req.args ?? {}
+              const title = typeof args.title === 'string' ? args.title : ''
+              const content = typeof args.content === 'string' ? args.content : ''
+              const isNote = req.name === 'create_note_tool' && (title !== '' || content !== '')
+              const description = req.description ?? ''
+              const descExpanded = expandedApproval[`${expandKey}:desc`] === true
+              return (
+                <div key={`${req.name}-${i}`} className="rounded-md bg-[var(--color-bg-secondary)] p-3 text-xs space-y-2">
+                  <div className="font-medium text-[var(--color-text)] text-sm">
+                    {approvalToolLabels[req.name] || req.name}
+                    <span className="ml-2 font-normal text-[var(--color-text-tertiary)]">{req.name}</span>
+                  </div>
+                  {description !== '' && (
+                    <p className={`leading-relaxed text-[var(--color-text-secondary)]${descExpanded ? ' max-h-96 overflow-y-auto pr-2' : ''}`}>
+                      {descExpanded ? stripMarkdown(description) : truncateText(stripMarkdown(description), APPROVAL_PREVIEW_LIMIT)}
+                      {description.length > APPROVAL_PREVIEW_LIMIT && (
+                        <button
+                          type="button"
+                          onClick={() => setExpandedApproval((prev) => ({ ...prev, [`${expandKey}:desc`]: !descExpanded }))}
+                          className="ml-1 text-[var(--color-accent)] hover:underline"
+                        >
+                          {descExpanded ? '收起' : '展开'}
+                        </button>
+                      )}
+                    </p>
+                  )}
+                  {isNote ? (
+                    <>
+                      {title !== '' && (
+                        <div className="flex gap-2">
+                          <span className="shrink-0 text-[var(--color-text-tertiary)]">标题：</span>
+                          <span className="font-medium text-[var(--color-text)]">{title}</span>
+                        </div>
+                      )}
+                      {content !== '' && (
+                        <div>
+                          <div className="text-[var(--color-text-tertiary)]">正文预览：</div>
+                          {expanded ? (
+                            <div className={`prose prose-sm max-w-none markdown-body${theme === 'dark' ? ' prose-invert' : ''} max-h-96 overflow-y-auto pr-2`}>
+                              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight, rehypeRaw]}>
+                                {content}
+                              </ReactMarkdown>
+                            </div>
+                          ) : (
+                            <p className="whitespace-pre-wrap break-all text-[var(--color-text-secondary)]">
+                              {truncateText(stripMarkdown(content), APPROVAL_PREVIEW_LIMIT)}
+                            </p>
+                          )}
+                          {content.length > APPROVAL_PREVIEW_LIMIT && (
+                            <button
+                              type="button"
+                              onClick={toggleExpanded}
+                              className="mt-1 text-[var(--color-accent)] hover:underline"
+                            >
+                              {expanded ? '收起' : '展开全文'}
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div className="space-y-1">
+                      {Object.entries(args).map(([k, v]) => (
+                        <div key={k} className="flex gap-2">
+                          <span className="shrink-0 text-[var(--color-text-tertiary)]">{k}：</span>
+                          <span className="whitespace-pre-wrap break-all text-[var(--color-text-secondary)]">
+                            {truncateText(typeof v === 'string' ? v : JSON.stringify(v), APPROVAL_ARG_LIMIT)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleApprove}
+                disabled={approveSubmitting}
+                className="px-4 py-1.5 rounded-md bg-[var(--color-accent)] text-white text-sm disabled:opacity-50"
+              >
+                同意
+              </button>
+              <button
+                onClick={handleReject}
+                disabled={approveSubmitting}
+                className="px-4 py-1.5 rounded-md border border-[var(--color-border)] text-sm disabled:opacity-50"
+              >
+                拒绝
+              </button>
+              <input
+                value={rejectReason}
+                onChange={(e) => setRejectReason(e.target.value)}
+                placeholder="拒绝原因（可选）"
+                className="flex-1 min-w-0 px-3 py-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] text-xs"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="border-t border-[var(--color-border)] bg-[var(--color-card)] px-6 py-4">
         <div className="max-w-3xl mx-auto flex gap-3">
           <textarea
@@ -508,7 +773,7 @@ export default function AIChat() {
           />
           <button
             onClick={() => handleSend(input)}
-            disabled={!input.trim() || loading}
+            disabled={!input.trim() || loading || approveSubmitting}
             className="flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--color-accent)] text-white hover:bg-blue-700 disabled:opacity-40 transition-colors shrink-0"
           >
             {loading ? <Loader2 size={16} className="animate-spin" /> : <Send size={16} />}

--- a/front/src/types/api.ts
+++ b/front/src/types/api.ts
@@ -71,6 +71,7 @@ export interface ChatSession {
   metadata?: Record<string, unknown>
   created_at: string
   updated_at: string
+  pending_run_id?: string | null
 }
 
 export interface ChatMessage {
@@ -155,12 +156,30 @@ export interface ReviewListData {
   total_count: number
 }
 
+export interface ApprovalActionRequest {
+  name: string
+  args: Record<string, unknown>
+  description?: string
+}
+
+export interface ApprovalReviewConfig {
+  action_name: string
+  allowed_decisions: ('approve' | 'reject')[]
+}
+
+export interface ApprovalPayload {
+  action_requests: ApprovalActionRequest[]
+  review_configs: ApprovalReviewConfig[]
+}
+
 export interface SSEMessage {
-  type: 'thinking' | 'response' | 'done' | 'error'
+  type: 'thinking' | 'response' | 'done' | 'error' | 'interrupt'
   content?: string
   session_id?: string
   stage?: string
   details?: Record<string, unknown>
+  run_id?: string
+  payload?: ApprovalPayload
 }
 
 export interface KnowledgeSSEMessage {


### PR DESCRIPTION
## 改动内容

- HITL 审批中断与恢复：白名单工具（`create_note_tool`）执行前中断，前端审批卡 approve/reject 后从原位置继续；页面刷新/断连后可凭 `pending_run_id` 恢复
- MySQL checkpoint 持久化：新增 `agent_checkpoints` / `agent_checkpoint_writes` 两张表与自定义 saver（`agent/checkpoint/`），中断现场落库
- 审批保留：审批完成后 thread 不删除、`pending` 保留到下次中断覆盖；同一 run 重复 resume 返回 `ALREADY_COMPLETED`，不重复执行工具/落镜像
- 查看能力：新增 `GET /session/{id}/approval`，可查上次审批快照（含已完成的，`active=false`）；原 `/pending` 保持“仅等审批中”语义，前端无 breaking change
- 前端：SSE `interrupt` 帧处理、审批卡展示与提交、待审批恢复入口

## 测试

- `tests/agent/test_agent.py`（32）、集成/saver/hitl（10）、chat_api/session/models（53）：共 95 个相关用例通过
- 覆盖：中断帧与 pending 落库、守卫拦截、resume 完成保留、重放拒绝、新问题放行、approve/reject 端到端

Refs #15